### PR TITLE
ID-B-33

### DIFF
--- a/ProjectPet.sln
+++ b/ProjectPet.sln
@@ -103,6 +103,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{B50E2D40
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectPet.DiscussionsModule.UnitTests.Domain", "src\DiscussionsModule\Tests\ProjectPet.DiscussionsModule.UnitTests.Domain\ProjectPet.DiscussionsModule.UnitTests.Domain.csproj", "{4DF99C8F-0791-4FDC-8301-4E1F67E4D375}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectPet.VolunteerRequests.IntegrationTests", "src\VolunteerRequest\Tests\ProjectPet.VolunteerRequests.IntegrationTests\ProjectPet.VolunteerRequests.IntegrationTests.csproj", "{5B011980-8DD9-4ABD-BF3A-100DF0CAE5D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -265,6 +267,10 @@ Global
 		{4DF99C8F-0791-4FDC-8301-4E1F67E4D375}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4DF99C8F-0791-4FDC-8301-4E1F67E4D375}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4DF99C8F-0791-4FDC-8301-4E1F67E4D375}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B011980-8DD9-4ABD-BF3A-100DF0CAE5D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B011980-8DD9-4ABD-BF3A-100DF0CAE5D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B011980-8DD9-4ABD-BF3A-100DF0CAE5D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B011980-8DD9-4ABD-BF3A-100DF0CAE5D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -318,6 +324,7 @@ Global
 		{85E71B9C-1751-411C-921A-F5C2637DEB9C} = {506545C2-EE0E-4101-BF31-A7A4AA16D8C1}
 		{B50E2D40-C184-406F-9156-0C563F8A4783} = {506545C2-EE0E-4101-BF31-A7A4AA16D8C1}
 		{4DF99C8F-0791-4FDC-8301-4E1F67E4D375} = {B50E2D40-C184-406F-9156-0C563F8A4783}
+		{5B011980-8DD9-4ABD-BF3A-100DF0CAE5D1} = {F764ABCE-BB2C-40C6-A707-DB9284FF295B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D2389C2A-A36A-40D0-BF7F-FB04E2ED085D}

--- a/bat/UpdateDatabase.bat
+++ b/bat/UpdateDatabase.bat
@@ -3,4 +3,5 @@ dotnet ef database update --connection Host=localhost;Port=5432;Database=project
 dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/Species/ProjectPet.Species.Infrastructure --context WriteDbContext
 dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/Volunteer/ProjectPet.Volunteer.Infrastructure --context WriteDbContext
 dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure --context WriteDbContext
+dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure --context WriteDbContext
 PAUSE

--- a/bat/UpdateDatabase.bat
+++ b/bat/UpdateDatabase.bat
@@ -2,4 +2,5 @@ cd ../
 dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/AccountsModule/ProjectPet.AccountsModule.Infrastructure --context AuthDbContext
 dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/Species/ProjectPet.Species.Infrastructure --context WriteDbContext
 dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/Volunteer/ProjectPet.Volunteer.Infrastructure --context WriteDbContext
+dotnet ef database update --connection Host=localhost;Port=5432;Database=project_pet;Username=postgres;Password=postgres; -s src/ProjectPet.Web/ProjectPet.Web.csproj -p src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure --context WriteDbContext
 PAUSE

--- a/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
@@ -43,8 +43,6 @@ public class AccountsModuleContractImplementation : IAccountsModuleContract
         if (getUserRes.IsFailure)
             return getUserRes.Error;
 
-        var transaction = await _unitOfWork.BeginTransactionAsync(ctoken);
-
         var data = new VolunteerAccount(
             accountDto.PaymentInfos.Select(x => new PaymentInfo(x.Title, x.Instructions)),
             accountDto.Experience,

--- a/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
@@ -1,0 +1,68 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.AccountsModule.Application.Interfaces;
+using ProjectPet.AccountsModule.Contracts;
+using ProjectPet.AccountsModule.Contracts.Dto;
+using ProjectPet.AccountsModule.Domain;
+using ProjectPet.AccountsModule.Domain.Accounts;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.SharedKernel.ValueObjects;
+
+namespace ProjectPet.AccountsModule.Application;
+public class AccountsModuleContractImplementation : IAccountsModuleContract
+{
+    private readonly IPermissionModifierRepository _permissionModRepository;
+    private readonly IAccountRepository _accountRepository;
+
+    public AccountsModuleContractImplementation(
+        IPermissionModifierRepository permissionModifier,
+        IAccountRepository accountRepository)
+    {
+        _permissionModRepository = permissionModifier;
+        _accountRepository = accountRepository;
+    }
+
+    public async Task<UnitResult<Error>> AddVolunteerDataToUserAsync(Guid userId,
+                                                                VolunteerAccountDto accountDto,
+                                                                CancellationToken ctoken = default)
+    {
+        var getUserRes = await _accountRepository.GetByIdAsync(userId, ctoken);
+        if (getUserRes.IsFailure)
+            return getUserRes.Error;
+
+        var data = new VolunteerAccount(
+            accountDto.PaymentInfos.Select(x => new PaymentInfo(x.Title, x.Instructions)),
+            accountDto.Experience,
+            accountDto.Certifications);
+
+        var setVolunteerRes = getUserRes.Value.SetVolunteerData(data);
+        if (setVolunteerRes.IsFailure)
+            return setVolunteerRes.Error;
+
+        return Result.Success<Error>();
+    }
+
+    public async Task<Result<Guid, Error>> CreatePermissionModifierAsync(Guid userId,
+                                                                         PermissionModifierDto modifierDto,
+                                                                         CancellationToken ctoken = default)
+    {
+        var getUserRes = await _accountRepository.GetByIdAsync(userId, ctoken);
+        if (getUserRes.IsFailure)
+            return getUserRes.Error;
+
+        var createModifierRes = PermissionModifier.Create(
+            userId,
+            modifierDto.Code,
+            modifierDto.IsAllowed,
+            modifierDto.ExpiresAt);
+
+        if (createModifierRes.IsFailure)
+            return createModifierRes.Error;
+
+        var addRes = await _permissionModRepository.AddAsync(createModifierRes.Value, ctoken);
+        if (addRes.IsFailure)
+            return addRes.Error;
+
+        return addRes.Value;
+    }
+}

--- a/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
@@ -56,7 +56,6 @@ public class AccountsModuleContractImplementation : IAccountsModuleContract
         if (roleResult.Succeeded == false)
             return roleResult.Errors.Select(x => Error.Failure(x.Code, x.Description)).FirstOrDefault()!;
 
-        transaction.Commit();
         _logger.LogInformation("User (id {O1}) got role: {O2}", userId, VolunteerAccount.ROLENAME);
 
         return Result.Success<Error>();

--- a/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
@@ -1,5 +1,6 @@
 ﻿using CSharpFunctionalExtensions;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using ProjectPet.AccountsModule.Application.Interfaces;
 using ProjectPet.AccountsModule.Contracts;
 using ProjectPet.AccountsModule.Contracts.Dto;
@@ -18,20 +19,23 @@ public class AccountsModuleContractImplementation : IAccountsModuleContract
     private readonly IAccountRepository _accountRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly UserManager<User> _userManager;
+    private readonly ILogger<AccountsModuleContractImplementation> _logger;
 
     public AccountsModuleContractImplementation(
         IPermissionModifierRepository permissionModifier,
         IAccountRepository accountRepository,
         IUnitOfWork unitOfWork,
-        UserManager<User> userManager)
+        UserManager<User> userManager,
+        ILogger<AccountsModuleContractImplementation> logger)
     {
         _permissionModRepository = permissionModifier;
         _accountRepository = accountRepository;
         _unitOfWork = unitOfWork;
         _userManager = userManager;
+        _logger = logger;
     }
 
-    public async Task<UnitResult<Error>> AddVolunteerDataToUserAsync(Guid userId,
+    public async Task<UnitResult<Error>> MakeUserVolunteerAsync(Guid userId,
                                                                 VolunteerAccountDto accountDto,
                                                                 CancellationToken ctoken = default)
     {
@@ -55,6 +59,7 @@ public class AccountsModuleContractImplementation : IAccountsModuleContract
             return roleResult.Errors.Select(x => Error.Failure(x.Code, x.Description)).FirstOrDefault()!;
 
         transaction.Commit();
+        _logger.LogInformation("User (id {O1}) got role: {O2}", userId, VolunteerAccount.ROLENAME);
 
         return Result.Success<Error>();
     }
@@ -79,6 +84,15 @@ public class AccountsModuleContractImplementation : IAccountsModuleContract
         var addRes = await _permissionModRepository.AddAsync(createModifierRes.Value, ctoken);
         if (addRes.IsFailure)
             return addRes.Error;
+
+        var restrictedString = modifierDto.IsAllowed ? "given" : "restricted from";
+        var logString = "User (id {O1}) was " + $"{restrictedString}" + " a permission {O2} until {O3}";
+
+        _logger.LogInformation(
+            logString,
+            userId,
+            modifierDto.Code,
+            modifierDto.ExpiresAt);
 
         return addRes.Value;
     }

--- a/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Application/AccountsModuleContractImplementation.cs
@@ -1,25 +1,34 @@
 ﻿using CSharpFunctionalExtensions;
+using Microsoft.AspNetCore.Identity;
 using ProjectPet.AccountsModule.Application.Interfaces;
 using ProjectPet.AccountsModule.Contracts;
 using ProjectPet.AccountsModule.Contracts.Dto;
 using ProjectPet.AccountsModule.Domain;
 using ProjectPet.AccountsModule.Domain.Accounts;
+using ProjectPet.Core.Abstractions;
 using ProjectPet.SharedKernel.ErrorClasses;
 using ProjectPet.SharedKernel.SharedDto;
 using ProjectPet.SharedKernel.ValueObjects;
+using System.Data;
 
 namespace ProjectPet.AccountsModule.Application;
 public class AccountsModuleContractImplementation : IAccountsModuleContract
 {
     private readonly IPermissionModifierRepository _permissionModRepository;
     private readonly IAccountRepository _accountRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly UserManager<User> _userManager;
 
     public AccountsModuleContractImplementation(
         IPermissionModifierRepository permissionModifier,
-        IAccountRepository accountRepository)
+        IAccountRepository accountRepository,
+        IUnitOfWork unitOfWork,
+        UserManager<User> userManager)
     {
         _permissionModRepository = permissionModifier;
         _accountRepository = accountRepository;
+        _unitOfWork = unitOfWork;
+        _userManager = userManager;
     }
 
     public async Task<UnitResult<Error>> AddVolunteerDataToUserAsync(Guid userId,
@@ -30,6 +39,8 @@ public class AccountsModuleContractImplementation : IAccountsModuleContract
         if (getUserRes.IsFailure)
             return getUserRes.Error;
 
+        var transaction = await _unitOfWork.BeginTransactionAsync(ctoken);
+
         var data = new VolunteerAccount(
             accountDto.PaymentInfos.Select(x => new PaymentInfo(x.Title, x.Instructions)),
             accountDto.Experience,
@@ -38,6 +49,12 @@ public class AccountsModuleContractImplementation : IAccountsModuleContract
         var setVolunteerRes = getUserRes.Value.SetVolunteerData(data);
         if (setVolunteerRes.IsFailure)
             return setVolunteerRes.Error;
+
+        var roleResult = await _userManager.AddToRoleAsync(getUserRes.Value, VolunteerAccount.ROLENAME);
+        if (roleResult.Succeeded == false)
+            return roleResult.Errors.Select(x => Error.Failure(x.Code, x.Description)).FirstOrDefault()!;
+
+        transaction.Commit();
 
         return Result.Success<Error>();
     }

--- a/src/AccountsModule/ProjectPet.AccountsModule.Application/Features/Account/Commands/UpdateAccountPayment/UpdateAccountPaymentHandler.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Application/Features/Account/Commands/UpdateAccountPayment/UpdateAccountPaymentHandler.cs
@@ -1,8 +1,8 @@
 ﻿using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 using ProjectPet.AccountsModule.Application.Interfaces;
-using ProjectPet.AccountsModule.Domain.UserData;
 using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.ValueObjects;
 
 namespace ProjectPet.AccountsModule.Application.Features.Account.Commands.UpdateAccountPayment;
 

--- a/src/AccountsModule/ProjectPet.AccountsModule.Application/Interfaces/IPermissionModifierRepository.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Application/Interfaces/IPermissionModifierRepository.cs
@@ -1,0 +1,9 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.AccountsModule.Domain;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.AccountsModule.Application.Interfaces;
+public interface IPermissionModifierRepository
+{
+    Task<Result<Guid, Error>> AddAsync(PermissionModifier permissionModifier, CancellationToken cancellation = default);
+}

--- a/src/AccountsModule/ProjectPet.AccountsModule.Contracts/Dto/PermissionModifierDto.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Contracts/Dto/PermissionModifierDto.cs
@@ -1,0 +1,7 @@
+﻿namespace ProjectPet.AccountsModule.Contracts.Dto;
+public class PermissionModifierDto
+{
+    public string Code { get; init; } = string.Empty;
+    public bool IsAllowed { get; init; }
+    public DateTime ExpiresAt { get; init; }
+}

--- a/src/AccountsModule/ProjectPet.AccountsModule.Contracts/IAccountsModuleContract.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Contracts/IAccountsModuleContract.cs
@@ -1,0 +1,12 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.AccountsModule.Contracts.Dto;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.AccountsModule.Contracts;
+public interface IAccountsModuleContract
+{
+    Task<Result<Guid, Error>> CreatePermissionModifierAsync(
+        Guid userId,
+        PermissionModifierDto modifierDto,
+        CancellationToken ctoken = default);
+}

--- a/src/AccountsModule/ProjectPet.AccountsModule.Contracts/IAccountsModuleContract.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Contracts/IAccountsModuleContract.cs
@@ -11,7 +11,7 @@ public interface IAccountsModuleContract
         PermissionModifierDto modifierDto,
         CancellationToken ctoken = default);
 
-    Task<UnitResult<Error>> AddVolunteerDataToUserAsync(Guid userId,
+    Task<UnitResult<Error>> MakeUserVolunteerAsync(Guid userId,
         VolunteerAccountDto accountDto,
         CancellationToken ctoken = default);
 }

--- a/src/AccountsModule/ProjectPet.AccountsModule.Contracts/IAccountsModuleContract.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Contracts/IAccountsModuleContract.cs
@@ -1,6 +1,7 @@
 ﻿using CSharpFunctionalExtensions;
 using ProjectPet.AccountsModule.Contracts.Dto;
 using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.SharedDto;
 
 namespace ProjectPet.AccountsModule.Contracts;
 public interface IAccountsModuleContract
@@ -8,5 +9,9 @@ public interface IAccountsModuleContract
     Task<Result<Guid, Error>> CreatePermissionModifierAsync(
         Guid userId,
         PermissionModifierDto modifierDto,
+        CancellationToken ctoken = default);
+
+    Task<UnitResult<Error>> AddVolunteerDataToUserAsync(Guid userId,
+        VolunteerAccountDto accountDto,
         CancellationToken ctoken = default);
 }

--- a/src/AccountsModule/ProjectPet.AccountsModule.Domain/Accounts/VolunteerAccount.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Domain/Accounts/VolunteerAccount.cs
@@ -1,5 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
-using ProjectPet.AccountsModule.Domain.UserData;
+using ProjectPet.SharedKernel.ValueObjects;
 using System.Text.Json.Serialization;
 
 namespace ProjectPet.AccountsModule.Domain.Accounts;

--- a/src/AccountsModule/ProjectPet.AccountsModule.Domain/PermissionModifier.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Domain/PermissionModifier.cs
@@ -1,0 +1,51 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.Core.Validator;
+using ProjectPet.SharedKernel.Entities.AbstractBase;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.AccountsModule.Domain;
+public class PermissionModifier : EntityBase
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public User User { get; private set; }
+    public string Code { get; private set; } = string.Empty;
+    public bool IsAllowed { get; private set; }
+    public DateTime ExpiresAt { get; private set; }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    protected PermissionModifier(Guid id) : base(id) { } // efcore
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+    private PermissionModifier(Guid id,
+                               Guid userId,
+                               string code,
+                               bool isAllowed,
+                               DateTime expiresAt) : this(id)
+    {
+        UserId = userId;
+        Code = code;
+        IsAllowed = isAllowed;
+        ExpiresAt = expiresAt;
+    }
+
+    public static Result<PermissionModifier, Error> Create(Guid userId,
+                                                           string code,
+                                                           bool isAllowed,
+                                                           DateTime expiresAt)
+    {
+        if (expiresAt <= DateTime.UtcNow)
+            return Errors.General.ValueIsInvalid(expiresAt, nameof(expiresAt));
+
+        var strValidationResult = Validator.ValidatorString().Check(code, nameof(code));
+        if (strValidationResult.IsFailure)
+            return strValidationResult.Error;
+
+        return new PermissionModifier(
+            Guid.Empty,
+            userId,
+            code,
+            isAllowed,
+            expiresAt);
+    }
+}

--- a/src/AccountsModule/ProjectPet.AccountsModule.Domain/User.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Domain/User.cs
@@ -3,10 +3,10 @@ using Microsoft.AspNetCore.Identity;
 using ProjectPet.AccountsModule.Domain.Accounts;
 using ProjectPet.AccountsModule.Domain.UserData;
 using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.ValueObjects;
 
 namespace ProjectPet.AccountsModule.Domain;
 
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 public class User : IdentityUser<Guid>
 {
     public IReadOnlyList<SocialNetwork> SocialNetworks => _socialNetworks;
@@ -19,7 +19,9 @@ public class User : IdentityUser<Guid>
     public AdminAccount AdminData { get; private set; }
     public MemberAccount MemberData { get; private set; }
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     public User() { } //efcore
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
     public User(
         string username,
@@ -35,7 +37,6 @@ public class User : IdentityUser<Guid>
         MemberData = memberData!;
         AdminData = adminData!;
     }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
     public void UpdatePaymentMethods(IEnumerable<PaymentInfo> infos)
     {

--- a/src/AccountsModule/ProjectPet.AccountsModule.Domain/User.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Domain/User.cs
@@ -51,6 +51,12 @@ public class User : IdentityUser<Guid>
         _socialNetworks = networks.ToList();
     }
 
+    public UnitResult<Error> SetVolunteerData(VolunteerAccount volunteerData)
+    {
+        VolunteerData = volunteerData;
+        return Result.Success<Error>();
+    }
+
     #region Roled Users Factory Methods
     public static async Task<Result<User, Error[]>> CreateAdminAsync(
         UserManager<User> userManager,

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/AuthDbContext.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/AuthDbContext.cs
@@ -17,6 +17,7 @@ public class AuthDbContext(IConfiguration configuration, IOptions<OptionsDb> opt
     public DbSet<Permission> Permissions => Set<Permission>();
     public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
     public DbSet<RefreshSession> RefreshSessions => Set<RefreshSession>();
+    public DbSet<PermissionModifier> PermissionModifiers => Set<PermissionModifier>();
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -39,6 +40,7 @@ public class AuthDbContext(IConfiguration configuration, IOptions<OptionsDb> opt
         modelBuilder.ApplyConfiguration(new RefreshSessionConfiguration());
         modelBuilder.ApplyConfiguration(new RolePermissionConfiguration());
         modelBuilder.ApplyConfiguration(new UserConfiguration());
+        modelBuilder.ApplyConfiguration(new PermissionModifierConfiguration());
 
         modelBuilder.Entity<Role>()
             .ToTable("roles");

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/Configurations/Write/PermissionModifierConfiguration.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/Configurations/Write/PermissionModifierConfiguration.cs
@@ -7,7 +7,7 @@ internal class PermissionModifierConfiguration : IEntityTypeConfiguration<Permis
 {
     public void Configure(EntityTypeBuilder<PermissionModifier> builder)
     {
-        builder.ToTable("permission-modifiers");
+        builder.ToTable("permission_modifiers");
 
         builder.HasKey(x => x.Id);
 

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/Configurations/Write/PermissionModifierConfiguration.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/Configurations/Write/PermissionModifierConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPet.AccountsModule.Domain;
+
+namespace ProjectPet.AccountsModule.Infrastructure.Database.Configurations.Write;
+internal class PermissionModifierConfiguration : IEntityTypeConfiguration<PermissionModifier>
+{
+    public void Configure(EntityTypeBuilder<PermissionModifier> builder)
+    {
+        builder.ToTable("permission-modifiers");
+
+        builder.HasKey(x => x.Id);
+
+        builder.HasOne(x => x.User)
+            .WithMany()
+            .HasForeignKey(x => x.UserId);
+
+        builder.Property(x => x.ExpiresAt)
+            .HasDefaultValue(DateTime.UtcNow.AddDays(1));
+    }
+}

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/ReadDbContext.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Database/ReadDbContext.cs
@@ -14,10 +14,6 @@ public class ReadDbContext(IConfiguration configuration, IOptions<OptionsDb> opt
 
     public DbSet<UserDto> Users => Set<UserDto>();
 
-    //public DbSet<Permission> Permissions => Set<Permission>();
-    //public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
-    //public DbSet<RefreshSession> RefreshSessions => Set<RefreshSession>();
-
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.UseNpgsql(DATABASE);

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/DependencyInjection.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
         builder.AddAuth();
         builder.Services.AddScoped<IDatabaseSeeder, DatabaseAccountsSeeder>();
         builder.Services.AddScoped<IAccountRepository, AccountRepository>();
+        builder.Services.AddScoped<IPermissionModifierRepository, PermissionModifierRepository>();
 
         builder.Services.Configure<AdminCredsOptions>(builder.Configuration.GetSection(AdminCredsOptions.SECTION));
 

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Options/AdminCredsOptions.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Options/AdminCredsOptions.cs
@@ -2,7 +2,7 @@
 public class AdminCredsOptions
 {
     public const string SECTION = "ADMIN";
-    public string USERNAME { get; init; } = String.Empty;
-    public string PASSWORD { get; init; } = String.Empty;
-    public string EMAIL { get; init; } = String.Empty;
+    public string USERNAME { get; init; } = "DEFAULTADMINUSERNAME";
+    public string PASSWORD { get; init; } = "Aa1#1234567890-123456";
+    public string EMAIL { get; init; } = "DEFAULTADMINUSERNAME@mail.com";
 }

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Repositories/AuthRepository.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Repositories/AuthRepository.cs
@@ -40,8 +40,10 @@ public class AuthRepository : IAuthRepository
     {
         var user = await _authDbContext.Users.FirstOrDefaultAsync(u => u.Id == userID, cancellationToken);
 
-        var roles = await _userManager.GetRolesAsync(user);
+        if (IsUserHasPermissionModifier(userID, permissionCode, out bool IsPermitted))
+            return IsPermitted;
 
+        var roles = await _userManager.GetRolesAsync(user!);
         var roleIds = _authDbContext.Roles.Where(r => roles.Contains(r.Name)).Select(x => x.Id).ToHashSet();
 
         var permissionExists = await _authDbContext.RolePermissions.AnyAsync
@@ -55,4 +57,17 @@ public class AuthRepository : IAuthRepository
         return permissionExists;
     }
 
+    private bool IsUserHasPermissionModifier(Guid userID, string code, out bool isPermitted)
+    {
+        isPermitted = false;
+
+        var modifier = _authDbContext.PermissionModifiers
+            .Where(x => DateTime.UtcNow >= x.ExpiresAt)
+            .FirstOrDefault(x => x.UserId == userID && Equals(x.Code, code));
+
+        if (modifier is null)
+            return false;
+
+        return modifier.IsAllowed;
+    }
 }

--- a/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Repositories/PermissionModifierRepository.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Infrastructure/Repositories/PermissionModifierRepository.cs
@@ -1,0 +1,24 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.AccountsModule.Application.Interfaces;
+using ProjectPet.AccountsModule.Domain;
+using ProjectPet.AccountsModule.Infrastructure.Database;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.AccountsModule.Infrastructure.Repositories;
+public class PermissionModifierRepository : IPermissionModifierRepository
+{
+    private readonly AuthDbContext _dbContext;
+
+    public PermissionModifierRepository(AuthDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Result<Guid, Error>> AddAsync(PermissionModifier modifier, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.PermissionModifiers.AddAsync(modifier, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return modifier.Id;
+    }
+}

--- a/src/AccountsModule/ProjectPet.AccountsModule.Presentation/DependencyInjection.cs
+++ b/src/AccountsModule/ProjectPet.AccountsModule.Presentation/DependencyInjection.cs
@@ -1,11 +1,13 @@
 ﻿using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using ProjectPet.AccountsModule.Application;
 using ProjectPet.AccountsModule.Application.Features.Account.Commands.UpdateAccountPayment;
 using ProjectPet.AccountsModule.Application.Features.Account.Commands.UpdateAccountSocials;
 using ProjectPet.AccountsModule.Application.Features.Account.Queries;
 using ProjectPet.AccountsModule.Application.Features.Auth.Commands.Login;
 using ProjectPet.AccountsModule.Application.Features.Auth.Commands.Register;
+using ProjectPet.AccountsModule.Contracts;
 
 namespace ProjectPet.AccountsModule.Presentation;
 public static class DependencyInjection
@@ -14,7 +16,8 @@ public static class DependencyInjection
     {
         return builder
             .AddValidators()
-            .AddAuthHandlers();
+            .AddAuthHandlers()
+            .AddContractImplementation();
     }
 
     private static IHostApplicationBuilder AddAuthHandlers(this IHostApplicationBuilder builder)
@@ -30,6 +33,12 @@ public static class DependencyInjection
     private static IHostApplicationBuilder AddValidators(this IHostApplicationBuilder builder)
     {
         builder.Services.AddValidatorsFromAssemblyContaining(typeof(DependencyInjection));
+        return builder;
+    }
+
+    private static IHostApplicationBuilder AddContractImplementation(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddScoped<IAccountsModuleContract, AccountsModuleContractImplementation>();
         return builder;
     }
 }

--- a/src/Core/ProjectPet.Core/ProjectPet.Core.csproj
+++ b/src/Core/ProjectPet.Core/ProjectPet.Core.csproj
@@ -9,10 +9,14 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
- 	<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
+ 	<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16">
  	 <PrivateAssets>all</PrivateAssets>
  	 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+ 	</PackageReference>
+ 	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.16">
+ 	  <PrivateAssets>all</PrivateAssets>
+ 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
  	</PackageReference>
  	<PackageReference Include="Scrutor" Version="5.0.2" />
   </ItemGroup>

--- a/src/Core/ProjectPet.Framework/Authorization/PermissionCodes.cs
+++ b/src/Core/ProjectPet.Framework/Authorization/PermissionCodes.cs
@@ -24,4 +24,8 @@ public static class PermissionCodes
     public const string SpeciesRead = "species.read";
     public const string SpeciesUpdate = "species.update";
     public const string SpeciesDelete = "species.delete";
+    public const string VolunteerRequestCreate = "volunteerrequest.create";
+    public const string VolunteerRequestRead = "volunteerrequest.read";
+    public const string VolunteerRequestUpdate = "volunteerrequest.update";
+    public const string VolunteerRequestAdmin = "volunteerrequest.admin";
 }

--- a/src/Core/ProjectPet.SharedKernel/SharedDto/VolunteerAccountDto.cs
+++ b/src/Core/ProjectPet.SharedKernel/SharedDto/VolunteerAccountDto.cs
@@ -3,7 +3,7 @@ namespace ProjectPet.SharedKernel.SharedDto;
 
 public class VolunteerAccountDto
 {
-    public List<PaymentInfoDto> PaymentInfos;
+    public List<PaymentInfoDto> PaymentInfos { get; init; }
     public int Experience { get; init; }
     public string[] Certifications { get; init; }
 }

--- a/src/Core/ProjectPet.SharedKernel/ValueObjects/PaymentInfo.cs
+++ b/src/Core/ProjectPet.SharedKernel/ValueObjects/PaymentInfo.cs
@@ -1,7 +1,7 @@
 ﻿using CSharpFunctionalExtensions;
 using System.Text.Json.Serialization;
 
-namespace ProjectPet.AccountsModule.Domain.UserData;
+namespace ProjectPet.SharedKernel.ValueObjects;
 public class PaymentInfo : ValueObject
 {
     public string Title { get; }

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/Class1.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.DiscussionsModule.Application;
-
-public class Class1
-{
-
-}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/DiscussionModuleContractImplementation.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/DiscussionModuleContractImplementation.cs
@@ -1,0 +1,36 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.DiscussionsModule.Application.Interfaces;
+using ProjectPet.DiscussionsModule.Contracts;
+using ProjectPet.DiscussionsModule.Domain.Models;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.DiscussionsModule.Application;
+
+public class DiscussionModuleContractImplementation : IDiscussionModuleContract
+{
+    private readonly IDiscussionsRepository _repository;
+
+    public DiscussionModuleContractImplementation(
+        IDiscussionsRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Result<Guid, Error>> CreateDiscussionAsync(
+        Guid relatedEntityId,
+        IEnumerable<Guid> participantUserIds)
+    {
+        var createRes = Discussion.Create(
+            relatedEntityId,
+            participantUserIds);
+
+        if (createRes.IsFailure)
+            return createRes.Error;
+
+        var saveRes = await _repository.Save(createRes.Value);
+        if (saveRes.IsFailure)
+            return saveRes.Error;
+
+        return createRes.Value.Id;
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/Interfaces/IDiscussionsRepository.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/Interfaces/IDiscussionsRepository.cs
@@ -1,0 +1,12 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.DiscussionsModule.Domain.Models;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.DiscussionsModule.Application.Interfaces;
+public interface IDiscussionsRepository
+{
+    Task<Result<Guid, Error>> AddAsync(Discussion discussion, CancellationToken cancellationToken = default);
+    Task<Result<Guid, Error>> Save(Discussion discussion, CancellationToken cancellationToken = default);
+    Task<Result<Discussion, Error>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Result<Guid, Error>> Delete(Discussion discussion, CancellationToken cancellationToken = default);
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/Interfaces/IReadDbContext.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/Interfaces/IReadDbContext.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ProjectPet.DiscussionsModule.Contracts.Dto;
+
+namespace ProjectPet.DiscussionsModule.Application.Interfaces;
+public interface IReadDbContext
+{
+    DbSet<DiscussionDto> Discussions { get; }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/ProjectPet.DiscussionsModule.Application.csproj
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Application/ProjectPet.DiscussionsModule.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/Class1.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.DiscussionsModule.Contracts;
-
-public class Class1
-{
-
-}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/Dto/DiscussionDto.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/Dto/DiscussionDto.cs
@@ -1,0 +1,9 @@
+﻿namespace ProjectPet.DiscussionsModule.Contracts.Dto;
+public class DiscussionDto
+{
+    public Guid Id { get; init; }
+    public Guid RelatedEntityId { get; init; }
+    public bool IsClosed { get; init; }
+    public IReadOnlyList<Guid> UserIds { get; init; } = [];
+    public List<MessageDto> Messages { get; init; } = [];
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/Dto/MessageDto.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/Dto/MessageDto.cs
@@ -1,0 +1,9 @@
+﻿namespace ProjectPet.DiscussionsModule.Contracts.Dto;
+public class MessageDto
+{
+    public Guid Id { get; init; }
+    public Guid UserId { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public string Text { get; init; } = string.Empty;
+    public bool IsEdited { get; init; }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/IDiscussionModuleContract.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/IDiscussionModuleContract.cs
@@ -1,0 +1,8 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.DiscussionsModule.Contracts;
+public interface IDiscussionModuleContract
+{
+    public Task<Result<Guid, Error>> CreateDiscussionAsync(Guid relatedEntityId, IEnumerable<Guid> participantUserIds);
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/ProjectPet.DiscussionsModule.Contracts.csproj
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Contracts/ProjectPet.DiscussionsModule.Contracts.csproj
@@ -1,9 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\ProjectPet.SharedKernel\ProjectPet.SharedKernel.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/Models/Discussion.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/Models/Discussion.cs
@@ -7,12 +7,15 @@ namespace ProjectPet.DiscussionsModule.Domain.Models;
 public class Discussion : EntityBase
 {
     public Guid RelatedEntityId { get; private set; }
-    public List<Guid> _userIds { get; private set; }
-    public List<Message> _messages { get; private set; }
-    public bool IsClosed { get; private set; }
 
     public IReadOnlyList<Guid> UserIds => _userIds.AsReadOnly();
+    private readonly List<Guid> _userIds = [];
     public IReadOnlyList<Message> Messages => _messages.AsReadOnly();
+    private readonly List<Message> _messages = [];
+
+    public bool IsClosed { get; private set; }
+
+
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     public Discussion() : base(Guid.Empty) {}
@@ -36,8 +39,8 @@ public class Discussion : EntityBase
         if (valresGuid.IsFailure)
             return valresGuid.Error;
 
-        if (userIds.Count() < 2)
-            return Error.Failure("user.count.invalid", "Need at least two participants to start a discussion!");
+        if (userIds.Count() != 2)
+            return Error.Failure("user.count.invalid", "Need exactly two participants to start a discussion!");
 
         return new Discussion(relatedEntityId,
                               userIds,

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/Models/Discussion.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/Models/Discussion.cs
@@ -18,7 +18,7 @@ public class Discussion : EntityBase
 
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-    public Discussion() : base(Guid.Empty) {}
+    public Discussion() : base(Guid.Empty) { }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
     private Discussion(Guid relatedEntityId,

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/Models/Message.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/Models/Message.cs
@@ -13,7 +13,7 @@ public class Message : EntityBase
     public bool IsEdited { get; private set; }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-    public Message() : base(Guid.Empty) {}
+    public Message() : base(Guid.Empty) { }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
     private Message(Guid userId,

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/ProjectPet.DiscussionsModule.Domain.csproj
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Domain/ProjectPet.DiscussionsModule.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Class1.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.DiscussionsModule.Infrastructure;
-
-public class Class1
-{
-
-}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Read/DiscussionDtoConfiguration.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Read/DiscussionDtoConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPet.DiscussionsModule.Contracts.Dto;
+using ProjectPet.DiscussionsModule.Domain.Models;
+using ProjectPet.Framework.EFExtensions;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure.Database.Configurations.Read;
+public class DiscussionDtoConfiguration : IEntityTypeConfiguration<DiscussionDto>
+{
+    public void Configure(EntityTypeBuilder<DiscussionDto> builder)
+    {
+        builder.ToTable($"{nameof(Discussion)}s");
+
+        builder.HasKey(x => x.Id);
+
+        builder.HasMany(x => x.Messages)
+            .WithOne()
+            .HasForeignKey("discussion_id")
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property(x => x.UserIds)
+            .JsonVOCollectionConverter()
+            .HasColumnName("userIds")
+            .HasColumnType("jsonb")
+            .IsRequired(false);
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Read/MessageDtoConfiguration.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Read/MessageDtoConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPet.DiscussionsModule.Contracts.Dto;
+using ProjectPet.DiscussionsModule.Domain.Models;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure.Database.Configurations.Read;
+public class MessageDtoConfiguration : IEntityTypeConfiguration<MessageDto>
+{
+    public void Configure(EntityTypeBuilder<MessageDto> builder)
+    {
+        builder.ToTable($"{nameof(Message)}s");
+
+        builder.HasKey(x => x.Id);
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Write/DiscussionConfiguration.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Write/DiscussionConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPet.DiscussionsModule.Domain.Models;
+using ProjectPet.Framework.EFExtensions;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure.Database.Configurations.Write;
+public class DiscussionConfiguration : IEntityTypeConfiguration<Discussion>
+{
+    public void Configure(EntityTypeBuilder<Discussion> builder)
+    {
+        builder.ToTable($"{nameof(Discussion)}s");
+        builder.HasKey(x => x.Id);
+
+        builder.HasMany(x => x.Messages)
+            .WithOne()
+            .HasForeignKey("discussion_id")
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property(x => x.UserIds)
+            .JsonVOCollectionConverter()
+            .HasColumnName("userIds")
+            .HasColumnType("jsonb")
+            .IsRequired(false);
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Write/MessageConfiguration.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/Configurations/Write/MessageConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPet.DiscussionsModule.Domain.Models;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure.Database.Configurations.Write;
+public class MessageConfiguration : IEntityTypeConfiguration<Message>
+{
+    public void Configure(EntityTypeBuilder<Message> builder)
+    {
+        builder.ToTable($"{nameof(Message)}s");
+
+        builder.HasKey(x => x.Id);
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/ReadDbContext.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/ReadDbContext.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using ProjectPet.Core.Options;
+using ProjectPet.DiscussionsModule.Application.Interfaces;
+using ProjectPet.DiscussionsModule.Contracts.Dto;
+using ProjectPet.DiscussionsModule.Infrastructure.Database.Configurations.Read;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure.Database;
+public class ReadDbContext(IConfiguration configuration) : DbContext, IReadDbContext
+{
+    private readonly string DATABASE = configuration[configuration.GetRequiredSection(OptionsDb.SECTION).Get<OptionsDb>()!.CStringKey];
+    public DbSet<DiscussionDto> Discussions => Set<DiscussionDto>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseNpgsql(DATABASE);
+        optionsBuilder.UseSnakeCaseNamingConvention();
+        optionsBuilder.UseLoggerFactory(CreateLoggerFactory());
+        optionsBuilder.EnableSensitiveDataLogging();
+        optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new DiscussionDtoConfiguration());
+        modelBuilder.ApplyConfiguration(new MessageDtoConfiguration());
+
+        modelBuilder.HasDefaultSchema("discussion-module");
+    }
+
+    private static ILoggerFactory CreateLoggerFactory()
+    {
+        return LoggerFactory.Create(builder => builder.AddConsole());
+    }
+}
+

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/WriteDbContext.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Database/WriteDbContext.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using ProjectPet.Core.Options;
+using ProjectPet.DiscussionsModule.Domain.Models;
+using ProjectPet.DiscussionsModule.Infrastructure.Database.Configurations.Write;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure.Database;
+
+public class WriteDbContext(IConfiguration configuration) : DbContext
+{
+    private readonly string DATABASE = configuration[configuration.GetRequiredSection(OptionsDb.SECTION).Get<OptionsDb>()!.CStringKey];
+    public DbSet<Discussion> Discussions => Set<Discussion>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseNpgsql(DATABASE);
+        optionsBuilder.UseSnakeCaseNamingConvention();
+        optionsBuilder.UseLoggerFactory(CreateLoggerFactory());
+        optionsBuilder.EnableSensitiveDataLogging();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new DiscussionConfiguration());
+        modelBuilder.ApplyConfiguration(new MessageConfiguration());
+
+        modelBuilder.HasDefaultSchema("discussion-module");
+    }
+
+    private static ILoggerFactory CreateLoggerFactory()
+    {
+        return LoggerFactory.Create(builder => builder.AddConsole());
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/DependencyInjection.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ProjectPet.Core.Abstractions;
+using ProjectPet.DiscussionsModule.Application.Interfaces;
+using ProjectPet.DiscussionsModule.Infrastructure.Database;
+using ProjectPet.DiscussionsModule.Infrastructure.Repositories;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure;
+public static class DependencyInjection
+{
+    public static IHostApplicationBuilder AddDiscussionsModuleInfrastructure(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddScoped<IReadDbContext, ReadDbContext>();
+
+        builder.Services.AddScoped<WriteDbContext>();
+
+        builder.Services.AddScoped<IDiscussionsRepository, DiscussionsRepository>();
+
+        builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+        return builder;
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/ProjectPet.DiscussionsModule.Infrastructure.csproj
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/ProjectPet.DiscussionsModule.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/ProjectPet.DiscussionsModule.Infrastructure.csproj
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/ProjectPet.DiscussionsModule.Infrastructure.csproj
@@ -6,7 +6,17 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+	<ItemGroup>
+		<PackageReference Include="CSharpFunctionalExtensions" Version="3.0.0" />
+		<PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+	</ItemGroup>
+		
   <ItemGroup>
+    <ProjectReference Include="..\..\Core\ProjectPet.Core\ProjectPet.Core.csproj" />
+    <ProjectReference Include="..\..\Core\ProjectPet.Framework\ProjectPet.Framework.csproj" />
     <ProjectReference Include="..\ProjectPet.DiscussionsModule.Application\ProjectPet.DiscussionsModule.Application.csproj" />
   </ItemGroup>
 

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Repositories/VolunteerRequestRepository.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/Repositories/VolunteerRequestRepository.cs
@@ -1,0 +1,51 @@
+﻿using CSharpFunctionalExtensions;
+using Microsoft.EntityFrameworkCore;
+using ProjectPet.DiscussionsModule.Application.Interfaces;
+using ProjectPet.DiscussionsModule.Domain.Models;
+using ProjectPet.DiscussionsModule.Infrastructure.Database;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure.Repositories;
+public class DiscussionsRepository : IDiscussionsRepository
+{
+    private readonly WriteDbContext _dbContext;
+    public DiscussionsRepository(WriteDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Result<Guid, Error>> AddAsync(Discussion discussion, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.Discussions.AddAsync(discussion, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return discussion.Id;
+    }
+
+    public async Task<Result<Guid, Error>> Delete(Discussion discussion, CancellationToken cancellationToken = default)
+    {
+        _dbContext.Discussions.Remove(discussion);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return discussion.Id;
+    }
+
+    public async Task<Result<Discussion, Error>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var result = await _dbContext.Discussions
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+
+        if (result is null)
+            return Errors.General.NotFound(typeof(Discussion), id);
+
+        return result;
+    }
+
+    public async Task<Result<Guid, Error>> Save(Discussion discussion, CancellationToken cancellationToken = default)
+    {
+        _dbContext.Discussions.Attach(discussion);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return discussion.Id;
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/UnitOfWork.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Infrastructure/UnitOfWork.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Storage;
+using ProjectPet.Core.Abstractions;
+using ProjectPet.DiscussionsModule.Infrastructure.Database;
+using System.Data;
+
+namespace ProjectPet.DiscussionsModule.Infrastructure;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly WriteDbContext _context;
+
+    public UnitOfWork(WriteDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+        return transaction.GetDbTransaction();
+    }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/Class1.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.DiscussionsModule.Presentation;
-
-public class Class1
-{
-
-}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/DependencyInjection.cs
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/DependencyInjection.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ProjectPet.DiscussionsModule.Application;
+using ProjectPet.DiscussionsModule.Contracts;
+
+namespace ProjectPet.DiscussionsModule.Presentation;
+public static class DependencyInjection
+{
+    public static IHostApplicationBuilder AddDiscussionModuleHandlers(this IHostApplicationBuilder builder)
+    {
+        return builder
+            .AddContractImplementation();
+    }
+
+    private static IHostApplicationBuilder AddContractImplementation(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddScoped<IDiscussionModuleContract, DiscussionModuleContractImplementation>();
+        return builder;
+    }
+}

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/ProjectPet.DiscussionsModule.Presentation.csproj
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/ProjectPet.DiscussionsModule.Presentation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/ProjectPet.DiscussionsModule.Presentation.csproj
+++ b/src/DiscussionsModule/ProjectPet.DiscussionsModule.Presentation/ProjectPet.DiscussionsModule.Presentation.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Core\ProjectPet.Framework\ProjectPet.Framework.csproj" />
     <ProjectReference Include="..\ProjectPet.DiscussionsModule.Application\ProjectPet.DiscussionsModule.Application.csproj" />
   </ItemGroup>
 

--- a/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/DiscussionTests.cs
+++ b/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/DiscussionTests.cs
@@ -14,7 +14,7 @@ public class DiscussionTests
                                                     List<Guid> users)
     {
         // Act
-        var sut = Discussion.Create(relatedEntity,users);
+        var sut = Discussion.Create(relatedEntity, users);
 
         // Assert
         sut.IsSuccess.Should().BeTrue();

--- a/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/DiscussionTests.cs
+++ b/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/DiscussionTests.cs
@@ -13,6 +13,12 @@ public class DiscussionTests
     public void CreateDiscussion_ValidEntry_Success(Guid relatedEntity,
                                                     List<Guid> users)
     {
+        users = new() 
+        {
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+        };
+
         // Act
         var sut = Discussion.Create(relatedEntity, users);
 
@@ -35,7 +41,6 @@ public class DiscussionTests
 
     [Theory]
     [InlineAmntOfGuids(2)]
-    [InlineAmntOfGuids(3)]
     public void CreateDiscussion_UserAmnt_Valid_Success(Guid relatedEntity,
                                                         List<Guid> users)
     {

--- a/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Discussions/ClosedDiscussionAttribute.cs
+++ b/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Discussions/ClosedDiscussionAttribute.cs
@@ -1,5 +1,5 @@
-﻿using AutoFixture.Xunit2;
-using AutoFixture;
+﻿using AutoFixture;
+using AutoFixture.Xunit2;
 using ProjectPet.DiscussionsModule.UnitTests.Domain.Fixtures.Discussions.Customizations;
 
 namespace ProjectPet.DiscussionsModule.UnitTests.Domain.Fixtures.Discussions;

--- a/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Discussions/CommentsDiscussionAttribute.cs
+++ b/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Discussions/CommentsDiscussionAttribute.cs
@@ -1,5 +1,5 @@
-﻿using AutoFixture.Xunit2;
-using AutoFixture;
+﻿using AutoFixture;
+using AutoFixture.Xunit2;
 using ProjectPet.DiscussionsModule.UnitTests.Domain.Fixtures.Discussions.Customizations;
 
 namespace ProjectPet.DiscussionsModule.UnitTests.Domain.Fixtures.Discussions;

--- a/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Discussions/Customizations/BaseDiscussionCustomization.cs
+++ b/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Discussions/Customizations/BaseDiscussionCustomization.cs
@@ -6,6 +6,8 @@ public class BaseDiscussionCustomization : ICustomization
 {
     public void Customize(IFixture fixture)
     {
+        fixture.RepeatCount = 2;
+
         Discussion discussion = Discussion.Create(
                 fixture.Create<Guid>(),
                 fixture.CreateMany<Guid>()).Value;

--- a/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Messages/Customizations/BaseMessageCustomization.cs
+++ b/src/DiscussionsModule/Tests/ProjectPet.DiscussionsModule.UnitTests.Domain/Fixtures/Messages/Customizations/BaseMessageCustomization.cs
@@ -11,7 +11,7 @@ public class BaseMessageCustomization : ICustomization
                 fixture.Create<string>()).Value;
 
         fixture.Freeze<Message>();
-                                  
+
         fixture.Customize<Message>(opts => opts
             .FromFactory(() => message));
     }

--- a/src/FileManagement/ProjectPet.FileManagement.Application/ProjectPet.FileManagement.Application.csproj
+++ b/src/FileManagement/ProjectPet.FileManagement.Application/ProjectPet.FileManagement.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 	</ItemGroup>
 

--- a/src/ProjectPet.Web/Json/Seeding/permissions.json
+++ b/src/ProjectPet.Web/Json/Seeding/permissions.json
@@ -24,6 +24,12 @@
     "species.create",
     "species.read",
     "species.update",
-    "species.delete"
+    "species.delete",
+
+    "volunteerrequest.create",
+    "volunteerrequest.read",
+    "volunteerrequest.update",
+    "volunteerrequest.admin"
+
   ]
 }

--- a/src/ProjectPet.Web/Json/Seeding/rolepermissions.json
+++ b/src/ProjectPet.Web/Json/Seeding/rolepermissions.json
@@ -1,6 +1,7 @@
 {
   "Admin": [
-    "admin.masterkey"
+    "admin.masterkey",
+    "volunteerrequest.admin"
   ],
   "Volunteer": [
     "owned.pets.create",
@@ -11,6 +12,9 @@
   ],
   "Member": [
     "self.member.edit",
-    "pets.read"
+    "pets.read",
+    "volunteerrequest.update",
+    "volunteerrequest.create",
+    "volunteerrequest.read"
   ]
 }

--- a/src/ProjectPet.Web/Program.cs
+++ b/src/ProjectPet.Web/Program.cs
@@ -5,6 +5,8 @@ using ProjectPet.SpeciesModule.Infrastructure;
 using ProjectPet.SpeciesModule.Presentation;
 using ProjectPet.VolunteerModule.Infrastructure;
 using ProjectPet.VolunteerModule.Presentation;
+using ProjectPet.VolunteerRequests.Infrastructure;
+using ProjectPet.VolunteerRequests.Presentation;
 using ProjectPet.Web;
 using ProjectPet.Web.Extentions;
 using ProjectPet.Web.MIddlewares;
@@ -35,6 +37,8 @@ builder.AddFileManagementInfrastructure();
 builder.AddAuthModuleHandlers();
 builder.AddAuthModuleInfrastructure();
 
+builder.AddVolunteerRequestsModuleHandlers();
+builder.AddVolunteerRequestModuleInfrastructure();
 #endregion
 
 builder.Services.AddValidation();

--- a/src/ProjectPet.Web/Program.cs
+++ b/src/ProjectPet.Web/Program.cs
@@ -1,5 +1,7 @@
 using ProjectPet.AccountsModule.Infrastructure;
 using ProjectPet.AccountsModule.Presentation;
+using ProjectPet.DiscussionsModule.Infrastructure;
+using ProjectPet.DiscussionsModule.Presentation;
 using ProjectPet.FileManagement.Infrastructure;
 using ProjectPet.SpeciesModule.Infrastructure;
 using ProjectPet.SpeciesModule.Presentation;
@@ -39,6 +41,9 @@ builder.AddAuthModuleInfrastructure();
 
 builder.AddVolunteerRequestsModuleHandlers();
 builder.AddVolunteerRequestModuleInfrastructure();
+
+builder.AddDiscussionModuleHandlers();
+builder.AddDiscussionsModuleInfrastructure();
 #endregion
 
 builder.Services.AddValidation();

--- a/src/ProjectPet.Web/ProjectPet.Web.csproj
+++ b/src/ProjectPet.Web/ProjectPet.Web.csproj
@@ -40,6 +40,8 @@
 	  <ProjectReference Include="..\FileManagement\ProjectPet.FileManagement.Presentation\ProjectPet.FileManagement.Presentation.csproj" />
 	  <ProjectReference Include="..\Species\ProjectPet.Species.Infrastructure\ProjectPet.SpeciesModule.Infrastructure.csproj" />
 	  <ProjectReference Include="..\Species\ProjectPet.Species.Presentation\ProjectPet.SpeciesModule.Presentation.csproj" />
+	  <ProjectReference Include="..\VolunteerRequest\ProjectPet.VolunteerRequest.Infrastructure\ProjectPet.VolunteerRequests.Infrastructure.csproj" />
+	  <ProjectReference Include="..\VolunteerRequest\ProjectPet.VolunteerRequest.Presentation\ProjectPet.VolunteerRequests.Presentation.csproj" />
 	  <ProjectReference Include="..\Volunteer\ProjectPet.Volunteer.Infrastructure\ProjectPet.VolunteerModule.Infrastructure.csproj" />
 	  <ProjectReference Include="..\Volunteer\ProjectPet.Volunteer.Presentation\ProjectPet.VolunteerModule.Presentation.csproj" />
 	</ItemGroup>

--- a/src/ProjectPet.Web/ProjectPet.Web.csproj
+++ b/src/ProjectPet.Web/ProjectPet.Web.csproj
@@ -36,6 +36,8 @@
 	  <ProjectReference Include="..\AccountsModule\ProjectPet.AccountsModule.Infrastructure\ProjectPet.AccountsModule.Infrastructure.csproj" />
 	  <ProjectReference Include="..\AccountsModule\ProjectPet.AccountsModule.Presentation\ProjectPet.AccountsModule.Presentation.csproj" />
 	  <ProjectReference Include="..\Core\ProjectPet.Core\ProjectPet.Core.csproj" />
+	  <ProjectReference Include="..\DiscussionsModule\ProjectPet.DiscussionsModule.Infrastructure\ProjectPet.DiscussionsModule.Infrastructure.csproj" />
+	  <ProjectReference Include="..\DiscussionsModule\ProjectPet.DiscussionsModule.Presentation\ProjectPet.DiscussionsModule.Presentation.csproj" />
 	  <ProjectReference Include="..\FileManagement\ProjectPet.FileManagement.Infrastructure\ProjectPet.FileManagement.Infrastructure.csproj" />
 	  <ProjectReference Include="..\FileManagement\ProjectPet.FileManagement.Presentation\ProjectPet.FileManagement.Presentation.csproj" />
 	  <ProjectReference Include="..\Species\ProjectPet.Species.Infrastructure\ProjectPet.SpeciesModule.Infrastructure.csproj" />

--- a/src/Species/ProjectPet.Species.Application/ProjectPet.SpeciesModule.Application.csproj
+++ b/src/Species/ProjectPet.Species.Application/ProjectPet.SpeciesModule.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Volunteer/ProjectPet.Volunteer.Application/ProjectPet.VolunteerModule.Application.csproj
+++ b/src/Volunteer/ProjectPet.Volunteer.Application/ProjectPet.VolunteerModule.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Class1.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.VolunteerRequests.Application;
-
-public class Class1
-{
-
-}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveCommand.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveCommand.cs
@@ -1,0 +1,3 @@
+﻿namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Approve;
+public record ApproveCommand(Guid RequestId)
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveHandler.cs
@@ -58,7 +58,7 @@ public class ApproveHandler
         var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
         if (saveRes.IsFailure)
             return saveRes.Error;
-        
+
         transaction.Commit();
 
         _logger.LogInformation(

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveHandler.cs
@@ -1,0 +1,62 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.AccountsModule.Contracts;
+using ProjectPet.Core.Abstractions;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Approve;
+public class ApproveHandler
+{
+    private readonly IVolunteerRequestRepository _requestRepository;
+    private readonly IAccountsModuleContract _accountsModule;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ApproveHandler(
+        IVolunteerRequestRepository requestRepository,
+        IAccountsModuleContract accountsModule,
+        IUnitOfWork unitOfWork)
+    {
+        _requestRepository = requestRepository;
+        _accountsModule = accountsModule;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<UnitResult<Error>> HandleAsync(
+        ApproveCommand command,
+        CancellationToken cancellationToken)
+    {
+        var transaction = await _unitOfWork.BeginTransactionAsync(cancellationToken);
+
+        var requestRes = await _requestRepository.GetByIdAsync(command.RequestId, cancellationToken);
+        if (requestRes.IsFailure)
+            return requestRes.Error;
+
+        var approveRes = requestRes.Value.ApproveRequest();
+        if (approveRes.IsFailure)
+            return approveRes.Error;
+
+        var data = new VolunteerAccountDto()
+        {
+            Certifications = requestRes.Value.VolunteerData.Certifications,
+            Experience = requestRes.Value.VolunteerData.Experience,
+            PaymentInfos = requestRes.Value.VolunteerData.PaymentInfos.Select(x => new PaymentInfoDto(x.Title, x.Instructions)).ToList()
+        };
+
+        var addDataToUserRes = await _accountsModule.MakeUserVolunteerAsync(
+            requestRes.Value.UserId,
+            data,
+            cancellationToken);
+
+        if (addDataToUserRes.IsFailure)
+            return addDataToUserRes.Error;
+
+        var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
+        if (saveRes.IsFailure)
+            return saveRes.Error;
+        
+        transaction.Commit();
+
+        return Result.Success<Error>();
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Approve/ApproveHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
 using ProjectPet.AccountsModule.Contracts;
 using ProjectPet.Core.Abstractions;
 using ProjectPet.SharedKernel.ErrorClasses;
@@ -11,15 +12,18 @@ public class ApproveHandler
     private readonly IVolunteerRequestRepository _requestRepository;
     private readonly IAccountsModuleContract _accountsModule;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<ApproveHandler> _logger;
 
     public ApproveHandler(
         IVolunteerRequestRepository requestRepository,
         IAccountsModuleContract accountsModule,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        ILogger<ApproveHandler> logger)
     {
         _requestRepository = requestRepository;
         _accountsModule = accountsModule;
         _unitOfWork = unitOfWork;
+        _logger = logger;
     }
 
     public async Task<UnitResult<Error>> HandleAsync(
@@ -56,6 +60,11 @@ public class ApproveHandler
             return saveRes.Error;
         
         transaction.Commit();
+
+        _logger.LogInformation(
+            "Volunteer request (id {O1}) was approved. Was assigned admin (id {O2})",
+            requestRes.Value.Id,
+            requestRes.Value.AdminId);
 
         return Result.Success<Error>();
     }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Create/CreateCommand.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Create/CreateCommand.cs
@@ -1,0 +1,12 @@
+﻿using ProjectPet.Core.Abstractions;
+using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Create;
+public record CreateCommand(
+    VolunteerAccountDto VolunteerAccountDto,
+    Guid UserId) : IMapFromRequest<CreateCommand, CreateVolunteerRequestRequest, Guid>
+{
+    public static CreateCommand FromRequest(CreateVolunteerRequestRequest request, Guid userId)
+        => new CreateCommand(request.AccountDto, userId);
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Create/CreateHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Create/CreateHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
 using ProjectPet.SharedKernel.ErrorClasses;
 using ProjectPet.SharedKernel.ValueObjects;
 using ProjectPet.VolunteerRequests.Application.Interfaces;
@@ -8,11 +9,14 @@ namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Co
 public class CreateHandler
 {
     private readonly IVolunteerRequestRepository _requestRepository;
+    private readonly ILogger<CreateHandler> _logger;
 
     public CreateHandler(
-        IVolunteerRequestRepository requestRepository)
+        IVolunteerRequestRepository requestRepository,
+        ILogger<CreateHandler> logger)
     {
         _requestRepository = requestRepository;
+        _logger = logger;
     }
 
     public async Task<Result<Guid, Error>> HandleAsync(
@@ -35,6 +39,11 @@ public class CreateHandler
         var addResult = await _requestRepository.AddAsync(createResult.Value, cancellationToken);
         if (addResult.IsFailure)
             return addResult.Error;
+
+        _logger.LogInformation(
+            "Volunteer request (id {O1}) was created by user (id {O2})",
+            createResult.Value.Id,
+            createResult.Value.UserId);
 
         return createResult.Value.Id;
     }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Create/CreateHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Create/CreateHandler.cs
@@ -1,0 +1,41 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.ValueObjects;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Domain.Models;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Create;
+public class CreateHandler
+{
+    private readonly IVolunteerRequestRepository _requestRepository;
+
+    public CreateHandler(
+        IVolunteerRequestRepository requestRepository)
+    {
+        _requestRepository = requestRepository;
+    }
+
+    public async Task<Result<Guid, Error>> HandleAsync(
+        CreateCommand command,
+        CancellationToken cancellationToken)
+    {
+        VolunteerAccountData volunteerAccount = new VolunteerAccountData(
+            command.VolunteerAccountDto.PaymentInfos.Select(dto => new PaymentInfo(dto.Title, dto.Instructions)),
+            command.VolunteerAccountDto.Experience,
+            command.VolunteerAccountDto.Certifications);
+
+        var createResult = VolunteerRequest.Create(
+            command.UserId,
+            Guid.Empty,
+            volunteerAccount);
+        if (createResult.IsFailure)
+            return createResult.Error;
+
+
+        var addResult = await _requestRepository.AddAsync(createResult.Value, cancellationToken);
+        if (addResult.IsFailure)
+            return addResult.Error;
+
+        return createResult.Value.Id;
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Reject/RejectCommand.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Reject/RejectCommand.cs
@@ -1,0 +1,12 @@
+﻿using ProjectPet.Core.Abstractions;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Reject;
+public record RejectCommand(
+    string RejectionComment,
+    Guid RequestId,
+    string PermissionCode) : IMapFromRequest<RejectCommand, RejectVolunteerRequestRequest, Guid, string>
+{
+    public static RejectCommand FromRequest(RejectVolunteerRequestRequest request, Guid requestId, string permissionCode)
+        => new(request.RejectionComment, requestId, permissionCode);
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Reject/RejectHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Reject/RejectHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
 using ProjectPet.AccountsModule.Contracts;
 using ProjectPet.AccountsModule.Contracts.Dto;
 using ProjectPet.SharedKernel.ErrorClasses;
@@ -9,13 +10,16 @@ public class RejectHandler
 {
     private readonly IVolunteerRequestRepository _requestRepository;
     private readonly IAccountsModuleContract _accountsModule;
+    private readonly ILogger<RejectHandler> _logger;
 
     public RejectHandler(
         IVolunteerRequestRepository requestRepository,
-        IAccountsModuleContract accountsModule)
+        IAccountsModuleContract accountsModule,
+        ILogger<RejectHandler> logger)
     {
         _requestRepository = requestRepository;
         _accountsModule = accountsModule;
+        _logger = logger;
     }
 
     public async Task<Result<Guid, Error>> HandleAsync(
@@ -48,6 +52,11 @@ public class RejectHandler
         var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
         if (saveRes.IsFailure)
             return saveRes.Error;
+
+        _logger.LogInformation(
+            "Volunteer request (id {O1}) was rejected by user (id {O2})",
+            requestRes.Value.Id,
+            requestRes.Value.UserId);
 
         return requestRes.Value.Id;
     }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Reject/RejectHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Reject/RejectHandler.cs
@@ -1,0 +1,54 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.AccountsModule.Contracts;
+using ProjectPet.AccountsModule.Contracts.Dto;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Reject;
+public class RejectHandler
+{
+    private readonly IVolunteerRequestRepository _requestRepository;
+    private readonly IAccountsModuleContract _accountsModule;
+
+    public RejectHandler(
+        IVolunteerRequestRepository requestRepository,
+        IAccountsModuleContract accountsModule)
+    {
+        _requestRepository = requestRepository;
+        _accountsModule = accountsModule;
+    }
+
+    public async Task<Result<Guid, Error>> HandleAsync(
+        RejectCommand command,
+        CancellationToken cancellationToken)
+    {
+        var requestRes = await _requestRepository.GetByIdAsync(command.RequestId, cancellationToken);
+        if (requestRes.IsFailure)
+            return requestRes.Error;
+
+        var requestRevisionRes = requestRes.Value.RejectRequest(command.RejectionComment);
+        if (requestRevisionRes.IsFailure)
+            return requestRevisionRes.Error;
+
+        var permissionModifier = new PermissionModifierDto()
+        {
+            Code = command.PermissionCode,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+            IsAllowed = false
+        };
+
+        var preventUserFromPostingRes = await _accountsModule.CreatePermissionModifierAsync(
+            requestRes.Value.UserId,
+            permissionModifier,
+            cancellationToken);
+
+        if (preventUserFromPostingRes.IsFailure)
+            return preventUserFromPostingRes.Error;
+
+        var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
+        if (saveRes.IsFailure)
+            return saveRes.Error;
+
+        return requestRes.Value.Id;
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/RequestRevision/RequestRevisionCommand.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/RequestRevision/RequestRevisionCommand.cs
@@ -1,0 +1,11 @@
+﻿using ProjectPet.Core.Abstractions;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.RequestRevision;
+public record RequestRevisionCommand(
+    string RevisionComment,
+    Guid RequestId) : IMapFromRequest<RequestRevisionCommand, RequestRevisionVolunteerRequestRequest, Guid>
+{
+    public static RequestRevisionCommand FromRequest(RequestRevisionVolunteerRequestRequest request, Guid requestId)
+        => new(request.RevisionComment, requestId);
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/RequestRevision/RequestRevisionHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/RequestRevision/RequestRevisionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
 using ProjectPet.SharedKernel.ErrorClasses;
 using ProjectPet.VolunteerRequests.Application.Interfaces;
 
@@ -6,11 +7,14 @@ namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Co
 public class RequestRevisionHandler
 {
     private readonly IVolunteerRequestRepository _requestRepository;
+    private readonly ILogger<RequestRevisionHandler> _logger;
 
     public RequestRevisionHandler(
-        IVolunteerRequestRepository requestRepository)
+        IVolunteerRequestRepository requestRepository,
+        ILogger<RequestRevisionHandler> logger)
     {
         _requestRepository = requestRepository;
+        _logger = logger;
     }
 
     public async Task<Result<Guid, Error>> HandleAsync(
@@ -28,6 +32,11 @@ public class RequestRevisionHandler
         var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
         if (saveRes.IsFailure)
             return saveRes.Error;
+
+        _logger.LogInformation(
+            "User (id {O2}) requested revision for volunteer request (id {O2})",
+            requestRes.Value.UserId,
+            requestRes.Value.Id);
 
         return requestRes.Value.Id;
     }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/RequestRevision/RequestRevisionHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/RequestRevision/RequestRevisionHandler.cs
@@ -1,0 +1,34 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.RequestRevision;
+public class RequestRevisionHandler
+{
+    private readonly IVolunteerRequestRepository _requestRepository;
+
+    public RequestRevisionHandler(
+        IVolunteerRequestRepository requestRepository)
+    {
+        _requestRepository = requestRepository;
+    }
+
+    public async Task<Result<Guid, Error>> HandleAsync(
+        RequestRevisionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var requestRes = await _requestRepository.GetByIdAsync(command.RequestId, cancellationToken);
+        if (requestRes.IsFailure)
+            return requestRes.Error;
+
+        var requestRevisionRes = requestRes.Value.RequestRevision(command.RevisionComment);
+        if (requestRevisionRes.IsFailure)
+            return requestRevisionRes.Error;
+
+        var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
+        if (saveRes.IsFailure)
+            return saveRes.Error;
+
+        return requestRes.Value.Id;
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Review/ReviewCommand.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Review/ReviewCommand.cs
@@ -1,0 +1,5 @@
+﻿namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Review;
+public record ReviewCommand(
+    Guid RequestId,
+    Guid AdminId)
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Review/ReviewHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Review/ReviewHandler.cs
@@ -1,0 +1,52 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.Core.Abstractions;
+using ProjectPet.DiscussionsModule.Contracts;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Review;
+public class ReviewHandler
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IDiscussionModuleContract _discussionModule;
+    private readonly IVolunteerRequestRepository _requestRepository;
+
+    public ReviewHandler(
+        IUnitOfWork unitOfWork,
+        IDiscussionModuleContract discussionModule,
+        IVolunteerRequestRepository requestRepository)
+    {
+        _unitOfWork = unitOfWork;
+        _discussionModule = discussionModule;
+        _requestRepository = requestRepository;
+    }
+
+    public async Task<Result<Guid, Error>> HandleAsync(
+        ReviewCommand command,
+        CancellationToken cancellationToken)
+    {
+        var requestRes = await _requestRepository.GetByIdAsync(command.RequestId, cancellationToken);
+        if (requestRes.IsFailure)
+            return requestRes.Error;
+
+        var transaction = await _unitOfWork.BeginTransactionAsync(cancellationToken);
+
+        var discussionRes = await _discussionModule.CreateDiscussionAsync(
+            requestRes.Value.Id,
+            [requestRes.Value.UserId, command.AdminId]);
+
+        if (discussionRes.IsFailure)
+            return discussionRes.Error;
+
+        var beginReviewRes = requestRes.Value.BeginReview(command.AdminId);
+        if (beginReviewRes.IsFailure)
+            return beginReviewRes.Error;
+
+        var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
+        if (saveRes.IsFailure)
+            return saveRes.Error;
+
+        transaction.Commit();
+        return saveRes.Value;
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Review/ReviewHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Review/ReviewHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
 using ProjectPet.Core.Abstractions;
 using ProjectPet.DiscussionsModule.Contracts;
 using ProjectPet.SharedKernel.ErrorClasses;
@@ -10,15 +11,18 @@ public class ReviewHandler
     private readonly IUnitOfWork _unitOfWork;
     private readonly IDiscussionModuleContract _discussionModule;
     private readonly IVolunteerRequestRepository _requestRepository;
+    private readonly ILogger<ReviewHandler> _logger;
 
     public ReviewHandler(
         IUnitOfWork unitOfWork,
         IDiscussionModuleContract discussionModule,
-        IVolunteerRequestRepository requestRepository)
+        IVolunteerRequestRepository requestRepository,
+        ILogger<ReviewHandler> logger)
     {
         _unitOfWork = unitOfWork;
         _discussionModule = discussionModule;
         _requestRepository = requestRepository;
+        _logger = logger;
     }
 
     public async Task<Result<Guid, Error>> HandleAsync(
@@ -47,6 +51,12 @@ public class ReviewHandler
             return saveRes.Error;
 
         transaction.Commit();
+
+        _logger.LogInformation(
+            "Volunteer request (id {O1}) taken into review by user (id {O2})",
+            requestRes.Value.Id,
+            requestRes.Value.UserId);
+
         return saveRes.Value;
     }
 }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Update/UpdateCommand.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Update/UpdateCommand.cs
@@ -1,0 +1,11 @@
+﻿using ProjectPet.Core.Abstractions;
+using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Update;
+public record UpdateCommand(
+    Guid RequestId,
+    VolunteerAccountDto VolunteerAccountDto) : IMapFromRequest<UpdateCommand, UpdateVolunteerRequestRequest, Guid>
+{
+    public static UpdateCommand FromRequest(UpdateVolunteerRequestRequest request, Guid requestId)
+        => new(requestId, request.VolunteerAccountDto);
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Update/UpdateHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Update/UpdateHandler.cs
@@ -1,0 +1,41 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.ValueObjects;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Domain.Models;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Update;
+public class UpdateHandler
+{
+    private readonly IVolunteerRequestRepository _requestRepository;
+
+    public UpdateHandler(
+        IVolunteerRequestRepository requestRepository)
+    {
+        _requestRepository = requestRepository;
+    }
+
+    public async Task<Result<Guid, Error>> HandleAsync(
+        UpdateCommand command,
+        CancellationToken cancellationToken)
+    {
+        var requestRes = await _requestRepository.GetByIdAsync(command.RequestId, cancellationToken);
+        if (requestRes.IsFailure)
+            return requestRes.Error;
+
+        VolunteerAccountData volunteerAccount = new VolunteerAccountData(
+            command.VolunteerAccountDto.PaymentInfos.Select(dto => new PaymentInfo(dto.Title, dto.Instructions)),
+            command.VolunteerAccountDto.Experience,
+            command.VolunteerAccountDto.Certifications);
+
+        var setDataRes = requestRes.Value.UpdateVolunteerData(volunteerAccount);
+        if (setDataRes.IsFailure)
+            return setDataRes.Error;
+
+        var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
+        if (saveRes.IsFailure)
+            return saveRes.Error;
+
+        return requestRes.Value.Id;
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Update/UpdateHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Commands/Update/UpdateHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
 using ProjectPet.SharedKernel.ErrorClasses;
 using ProjectPet.SharedKernel.ValueObjects;
 using ProjectPet.VolunteerRequests.Application.Interfaces;
@@ -8,11 +9,14 @@ namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Co
 public class UpdateHandler
 {
     private readonly IVolunteerRequestRepository _requestRepository;
+    private readonly ILogger<UpdateHandler> _logger;
 
     public UpdateHandler(
-        IVolunteerRequestRepository requestRepository)
+        IVolunteerRequestRepository requestRepository,
+        ILogger<UpdateHandler> logger)
     {
         _requestRepository = requestRepository;
+        _logger = logger;
     }
 
     public async Task<Result<Guid, Error>> HandleAsync(
@@ -35,6 +39,11 @@ public class UpdateHandler
         var saveRes = await _requestRepository.Save(requestRes.Value, cancellationToken);
         if (saveRes.IsFailure)
             return saveRes.Error;
+
+        _logger.LogInformation(
+            "Volunteer request (id {O1}) was updated by user (id {O2})",
+            requestRes.Value.Id,
+            requestRes.Value.UserId);
 
         return requestRes.Value.Id;
     }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByAdminIdPaginatedFiltered/GetByAdminIdPaginatedFilteredHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByAdminIdPaginatedFiltered/GetByAdminIdPaginatedFilteredHandler.cs
@@ -1,0 +1,34 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.Core.Extensions;
+using ProjectPet.Core.HelperModels;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
+public class GetByAdminIdPaginatedFilteredHandler
+{
+    private readonly IReadDbContext _readDbContext;
+
+    public GetByAdminIdPaginatedFilteredHandler(
+        IReadDbContext readDbContext)
+    {
+        _readDbContext = readDbContext;
+    }
+
+    public async Task<Result<PagedList<VolunteerRequestDto>, Error>> HandleAsync(
+        GetByAdminIdPaginatedFilteredQuery query,
+        CancellationToken cancellationToken)
+    {
+        var dbQuery = _readDbContext.VolunteerRequests
+            .Where(x => Equals(x.AdminId, query.AdminId))
+            .AsQueryable();
+
+        var statusFilter = query.Filters.Status;
+        statusFilter ??= VolunteerRequestStatusDto.onReview;
+
+        dbQuery = dbQuery.NullableWhere(statusFilter, x => x.Status == statusFilter);
+
+        return await dbQuery.ToPagedListAsync(query, cancellationToken);
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByAdminIdPaginatedFiltered/GetByAdminIdPaginatedFilteredHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByAdminIdPaginatedFiltered/GetByAdminIdPaginatedFilteredHandler.cs
@@ -28,7 +28,7 @@ public class GetByAdminIdPaginatedFilteredHandler
         statusFilter ??= VolunteerRequestStatusDto.onReview;
 
         dbQuery = dbQuery.NullableWhere(statusFilter, x => x.Status == statusFilter);
-        
+
         return await dbQuery.ToPagedListAsync(query, cancellationToken);
     }
 }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByAdminIdPaginatedFiltered/GetByAdminIdPaginatedFilteredQuery.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByAdminIdPaginatedFiltered/GetByAdminIdPaginatedFilteredQuery.cs
@@ -1,0 +1,13 @@
+﻿using ProjectPet.Core.Abstractions;
+using ProjectPet.Core.HelperModels;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
+public record GetByAdminIdPaginatedFilteredQuery(
+    Guid AdminId,
+    GetVolunteerRequestFilters Filters
+    ) : PaginatedQueryBase, IMapFromRequest<GetByAdminIdPaginatedFilteredQuery, GetVolunteerRequestFilteredPaginatedRequest, Guid>
+{
+    public static GetByAdminIdPaginatedFilteredQuery FromRequest(GetVolunteerRequestFilteredPaginatedRequest request, Guid adminId)
+        => new(adminId, request.Filters) { Page = request.Page, RecordAmount = request.Take };
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByUserIdPaginatedFiltered/GetByAdminIdPaginatedFilteredQuery.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByUserIdPaginatedFiltered/GetByAdminIdPaginatedFilteredQuery.cs
@@ -1,0 +1,13 @@
+﻿using ProjectPet.Core.Abstractions;
+using ProjectPet.Core.HelperModels;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByUserIdPaginatedFiltered;
+public record GetByUserIdPaginatedFilteredQuery(
+    Guid UserId,
+    GetVolunteerRequestFilters Filters
+    ) : PaginatedQueryBase, IMapFromRequest<GetByUserIdPaginatedFilteredQuery, GetVolunteerRequestFilteredPaginatedRequest, Guid>
+{
+    public static GetByUserIdPaginatedFilteredQuery FromRequest(GetVolunteerRequestFilteredPaginatedRequest request, Guid UserId)
+        => new(UserId, request.Filters) { Page = request.Page, RecordAmount = request.Take };
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByUserIdPaginatedFiltered/GetByUserIdPaginatedFilteredHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetByUserIdPaginatedFiltered/GetByUserIdPaginatedFilteredHandler.cs
@@ -5,30 +5,27 @@ using ProjectPet.SharedKernel.ErrorClasses;
 using ProjectPet.VolunteerRequests.Application.Interfaces;
 using ProjectPet.VolunteerRequests.Contracts.Dto;
 
-namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
-public class GetByAdminIdPaginatedFilteredHandler
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByUserIdPaginatedFiltered;
+public class GetByUserIdPaginatedFilteredHandler
 {
     private readonly IReadDbContext _readDbContext;
 
-    public GetByAdminIdPaginatedFilteredHandler(
+    public GetByUserIdPaginatedFilteredHandler(
         IReadDbContext readDbContext)
     {
         _readDbContext = readDbContext;
     }
 
     public async Task<Result<PagedList<VolunteerRequestDto>, Error>> HandleAsync(
-        GetByAdminIdPaginatedFilteredQuery query,
+        GetByUserIdPaginatedFilteredQuery query,
         CancellationToken cancellationToken)
     {
         var dbQuery = _readDbContext.VolunteerRequests
-            .Where(x => Equals(x.AdminId, query.AdminId))
+            .Where(x => Equals(x.UserId, query.UserId))
             .AsQueryable();
 
-        var statusFilter = query.Filters.Status;
-        statusFilter ??= VolunteerRequestStatusDto.onReview;
+        dbQuery = dbQuery.NullableWhere(query.Filters.Status, x => x.Status == query.Filters.Status);
 
-        dbQuery = dbQuery.NullableWhere(statusFilter, x => x.Status == statusFilter);
-        
         return await dbQuery.ToPagedListAsync(query, cancellationToken);
     }
 }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetUnassignedPaginated/GetUnassignedPaginatedHandler.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetUnassignedPaginated/GetUnassignedPaginatedHandler.cs
@@ -5,30 +5,26 @@ using ProjectPet.SharedKernel.ErrorClasses;
 using ProjectPet.VolunteerRequests.Application.Interfaces;
 using ProjectPet.VolunteerRequests.Contracts.Dto;
 
-namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
-public class GetByAdminIdPaginatedFilteredHandler
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetUnassignedPaginated;
+public class GetUnassignedPaginatedHandler
 {
     private readonly IReadDbContext _readDbContext;
 
-    public GetByAdminIdPaginatedFilteredHandler(
+    public GetUnassignedPaginatedHandler(
         IReadDbContext readDbContext)
     {
         _readDbContext = readDbContext;
     }
 
     public async Task<Result<PagedList<VolunteerRequestDto>, Error>> HandleAsync(
-        GetByAdminIdPaginatedFilteredQuery query,
+        GetUnassignedPaginatedQuery query,
         CancellationToken cancellationToken)
     {
         var dbQuery = _readDbContext.VolunteerRequests
-            .Where(x => Equals(x.AdminId, query.AdminId))
+            .Where(x => Equals(x.AdminId, Guid.Empty))
+            .Where(x => x.Status == VolunteerRequestStatusDto.submitted)
             .AsQueryable();
 
-        var statusFilter = query.Filters.Status;
-        statusFilter ??= VolunteerRequestStatusDto.onReview;
-
-        dbQuery = dbQuery.NullableWhere(statusFilter, x => x.Status == statusFilter);
-        
         return await dbQuery.ToPagedListAsync(query, cancellationToken);
     }
 }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetUnassignedPaginated/GetUnassignedPaginatedQuery.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Features/VolunteerRequests/Queries/GetUnassignedPaginated/GetUnassignedPaginatedQuery.cs
@@ -1,0 +1,12 @@
+﻿using ProjectPet.Core.Abstractions;
+using ProjectPet.Core.HelperModels;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetUnassignedPaginated;
+public record GetUnassignedPaginatedQuery :
+    PaginatedQueryBase,
+    IMapFromRequest<GetUnassignedPaginatedQuery, GetVolunteerRequestsPaginatedRequest>
+{
+    public static GetUnassignedPaginatedQuery FromRequest(GetVolunteerRequestsPaginatedRequest request)
+        => new() { Page = request.Page, RecordAmount = request.Take };
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Interfaces/IReadDbContext.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Interfaces/IReadDbContext.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+
+namespace ProjectPet.VolunteerRequests.Application.Interfaces;
+public interface IReadDbContext
+{
+    DbSet<VolunteerRequestDto> VolunteerRequests { get; }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Interfaces/IVolunteerRequestRepository.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/Interfaces/IVolunteerRequestRepository.cs
@@ -1,0 +1,12 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Domain.Models;
+
+namespace ProjectPet.VolunteerRequests.Application.Interfaces;
+public interface IVolunteerRequestRepository
+{
+    Task<Result<Guid, Error>> AddAsync(VolunteerRequest volunteer, CancellationToken cancellationToken = default);
+    Task<Result<Guid, Error>> Save(VolunteerRequest volunteer, CancellationToken cancellationToken = default);
+    Task<Result<VolunteerRequest, Error>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Result<Guid, Error>> Delete(VolunteerRequest volunteer, CancellationToken cancellationToken = default);
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/ProjectPet.VolunteerRequests.Application.csproj
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/ProjectPet.VolunteerRequests.Application.csproj
@@ -11,6 +11,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
+    <ProjectReference Include="..\..\AccountsModule\ProjectPet.AccountsModule.Contracts\ProjectPet.AccountsModule.Contracts.csproj" />
+    <ProjectReference Include="..\..\DiscussionsModule\ProjectPet.DiscussionsModule.Contracts\ProjectPet.DiscussionsModule.Contracts.csproj" />
     <ProjectReference Include="..\ProjectPet.VolunteerRequest.Contracts\ProjectPet.VolunteerRequests.Contracts.csproj" />
     <ProjectReference Include="..\ProjectPet.VolunteerRequest.Domain\ProjectPet.VolunteerRequests.Domain.csproj" />
   </ItemGroup>

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/ProjectPet.VolunteerRequests.Application.csproj
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Application/ProjectPet.VolunteerRequests.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Class1.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.VolunteerRequests.Contracts;
-
-public class Class1
-{
-
-}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Dto/VolunteerRequestDto.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Dto/VolunteerRequestDto.cs
@@ -1,0 +1,14 @@
+﻿using ProjectPet.SharedKernel.SharedDto;
+
+namespace ProjectPet.VolunteerRequests.Contracts.Dto;
+public class VolunteerRequestDto
+{
+    public Guid AdminId { get; init; }
+    public Guid UserId { get; init; }
+    public Guid DiscussionId { get; init; }
+    public VolunteerAccountDto VolunteerData { get; init; } = null!;
+    public VolunteerRequestStatusDto Status { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public string RejectionComment { get; init; } = string.Empty;
+}
+

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Dto/VolunteerRequestDto.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Dto/VolunteerRequestDto.cs
@@ -3,6 +3,7 @@
 namespace ProjectPet.VolunteerRequests.Contracts.Dto;
 public class VolunteerRequestDto
 {
+    public Guid Id { get; init; }
     public Guid AdminId { get; init; }
     public Guid UserId { get; init; }
     public Guid DiscussionId { get; init; }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Dto/VolunteerRequestStatusDto.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Dto/VolunteerRequestStatusDto.cs
@@ -1,0 +1,9 @@
+﻿namespace ProjectPet.VolunteerRequests.Contracts.Dto;
+public enum VolunteerRequestStatusDto
+{
+    submitted,
+    onReview,
+    rejected,
+    revisionRequired,
+    approved
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/CreateVolunteerRequestRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/CreateVolunteerRequestRequest.cs
@@ -4,4 +4,4 @@ namespace ProjectPet.VolunteerRequests.Contracts.Requests;
 public record CreateVolunteerRequestRequest(
     VolunteerAccountDto AccountDto,
     Guid UserId)
-{}
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/CreateVolunteerRequestRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/CreateVolunteerRequestRequest.cs
@@ -1,0 +1,7 @@
+﻿using ProjectPet.SharedKernel.SharedDto;
+
+namespace ProjectPet.VolunteerRequests.Contracts.Requests;
+public record CreateVolunteerRequestRequest(
+    VolunteerAccountDto AccountDto,
+    Guid UserId)
+{}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestByAdminIdFilters.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestByAdminIdFilters.cs
@@ -1,0 +1,5 @@
+﻿using ProjectPet.VolunteerRequests.Contracts.Dto;
+
+namespace ProjectPet.VolunteerRequests.Contracts.Requests;
+public record GetVolunteerRequestFilters(VolunteerRequestStatusDto? Status)
+{ };

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestFilteredPaginatedRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestFilteredPaginatedRequest.cs
@@ -3,4 +3,4 @@ public record GetVolunteerRequestFilteredPaginatedRequest(
     int Page,
     int Take,
     GetVolunteerRequestFilters Filters)
-{}
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestFilteredPaginatedRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestFilteredPaginatedRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace ProjectPet.VolunteerRequests.Contracts.Requests;
+public record GetVolunteerRequestFilteredPaginatedRequest(
+    int Page,
+    int Take,
+    GetVolunteerRequestFilters Filters)
+{}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestsPaginatedRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestsPaginatedRequest.cs
@@ -1,3 +1,5 @@
 ﻿namespace ProjectPet.VolunteerRequests.Contracts.Requests;
-public record GetVolunteerRequestsPaginatedRequest(int Page, int Take)
-{}
+public record GetVolunteerRequestsPaginatedRequest(
+    int Page,
+    int Take)
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestsPaginatedRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/GetVolunteerRequestsPaginatedRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace ProjectPet.VolunteerRequests.Contracts.Requests;
+public record GetVolunteerRequestsPaginatedRequest(int Page, int Take)
+{}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/RejectVolunteerRequestRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/RejectVolunteerRequestRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace ProjectPet.VolunteerRequests.Contracts.Requests;
+
+public record RejectVolunteerRequestRequest(
+    string RejectionComment)
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/RequestRevisionVolunteerRequestRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/RequestRevisionVolunteerRequestRequest.cs
@@ -1,4 +1,4 @@
 ﻿namespace ProjectPet.VolunteerRequests.Contracts.Requests;
 public record RequestRevisionVolunteerRequestRequest(
     string RevisionComment)
-{}
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/RequestRevisionVolunteerRequestRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/RequestRevisionVolunteerRequestRequest.cs
@@ -1,0 +1,4 @@
+﻿namespace ProjectPet.VolunteerRequests.Contracts.Requests;
+public record RequestRevisionVolunteerRequestRequest(
+    string RevisionComment)
+{}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/UpdateVolunteerRequestRequest.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Contracts/Requests/UpdateVolunteerRequestRequest.cs
@@ -1,0 +1,6 @@
+﻿using ProjectPet.SharedKernel.SharedDto;
+
+namespace ProjectPet.VolunteerRequests.Contracts.Requests;
+public record UpdateVolunteerRequestRequest(
+    VolunteerAccountDto VolunteerAccountDto)
+{ }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Domain/Models/VolunteerAccountData.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Domain/Models/VolunteerAccountData.cs
@@ -1,0 +1,29 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.SharedKernel.ValueObjects;
+
+namespace ProjectPet.VolunteerRequests.Domain.Models;
+public class VolunteerAccountData : ValueObject
+{
+    public List<PaymentInfo> PaymentInfos { get; init; }
+    public int Experience { get; init; }
+    public string[] Certifications { get; init; }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    public VolunteerAccountData() : base()
+    { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+    public VolunteerAccountData(IEnumerable<PaymentInfo> paymentInfos, int experience, string[] certifications)
+    {
+        PaymentInfos = paymentInfos.ToList();
+        Experience = experience;
+        Certifications = certifications;
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return Experience;
+        yield return Certifications.GetHashCode();
+        yield return PaymentInfos.GetHashCode();
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Class1.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.VolunteerRequests.Infrastructure;
-
-public class Class1
-{
-
-}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/Configurations/Read/VolunteerRequestDtoConfiguration.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/Configurations/Read/VolunteerRequestDtoConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPet.Framework.EFExtensions;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+using ProjectPet.VolunteerRequests.Domain.Models;
+
+namespace ProjectPet.VolunteerRequests.Infrastructure.Database.Configurations.Read;
+internal class VolunteerRequestDtoConfiguration : IEntityTypeConfiguration<VolunteerRequestDto>
+{
+    public void Configure(EntityTypeBuilder<VolunteerRequestDto> builder)
+    {
+        builder.ToTable($"{nameof(VolunteerRequest)}s");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.VolunteerData)
+            .JsonVOConverter()
+            .HasColumnName("volunteer_account_data")
+            .IsRequired(false)
+            .HasColumnType("jsonb");
+
+        builder.Property(x => x.Status)
+            .HasConversion<string>();
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/Configurations/Write/VolunteerRequestConfiguration.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/Configurations/Write/VolunteerRequestConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPet.Framework.EFExtensions;
+using ProjectPet.VolunteerRequests.Domain.Models;
+
+namespace ProjectPet.VolunteerRequests.Infrastructure.Database.Configurations.Write;
+public class VolunteerRequestConfiguration : IEntityTypeConfiguration<VolunteerRequest>
+{
+    public void Configure(EntityTypeBuilder<VolunteerRequest> builder)
+    {
+        builder.ToTable($"{nameof(VolunteerRequest)}s");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.VolunteerData)
+            .JsonVOConverter()
+            .HasColumnName("volunteer_account_data")
+            .IsRequired(false)
+            .HasColumnType("jsonb");
+
+        builder.Property(x => x.Status)
+            .HasConversion<string>();
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/ReadDbContext.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/ReadDbContext.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using ProjectPet.Core.Options;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+
+namespace ProjectPet.VolunteerRequests.Infrastructure.Database;
+public class ReadDbContext(IConfiguration configuration) : DbContext, IReadDbContext
+{
+    private readonly string DATABASE = configuration[configuration.GetRequiredSection(OptionsDb.SECTION).Get<OptionsDb>()!.CStringKey];
+    public DbSet<VolunteerRequestDto> VolunteerRequests => Set<VolunteerRequestDto>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseNpgsql(DATABASE);
+        optionsBuilder.UseSnakeCaseNamingConvention();
+        optionsBuilder.UseLoggerFactory(CreateLoggerFactory());
+        optionsBuilder.EnableSensitiveDataLogging();
+        optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(
+            typeof(ReadDbContext).Assembly,
+            x => x.FullName!.Contains("Configurations.Read")
+            );
+
+        modelBuilder.HasDefaultSchema("volunteer-requests");
+    }
+
+    private static ILoggerFactory CreateLoggerFactory()
+    {
+        return LoggerFactory.Create(builder => builder.AddConsole());
+    }
+}
+

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/WriteDbContext.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/WriteDbContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 using ProjectPet.Core.Options;
 using ProjectPet.VolunteerRequests.Domain.Models;
 
-namespace ProjectPet.VolunteerModule.Infrastructure.Database;
+namespace ProjectPet.VolunteerRequests.Infrastructure.Database;
 
 public class WriteDbContext(IConfiguration configuration) : DbContext
 {

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/WriteDbContext.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Database/WriteDbContext.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using ProjectPet.Core.Options;
+using ProjectPet.VolunteerRequests.Domain.Models;
+
+namespace ProjectPet.VolunteerModule.Infrastructure.Database;
+
+public class WriteDbContext(IConfiguration configuration) : DbContext
+{
+    private readonly string DATABASE = configuration[configuration.GetRequiredSection(OptionsDb.SECTION).Get<OptionsDb>()!.CStringKey];
+    public DbSet<VolunteerRequest> VolunteerRequests => Set<VolunteerRequest>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseNpgsql(DATABASE);
+        optionsBuilder.UseSnakeCaseNamingConvention();
+        optionsBuilder.UseLoggerFactory(CreateLoggerFactory());
+        optionsBuilder.EnableSensitiveDataLogging();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(
+            typeof(WriteDbContext).Assembly,
+            x => x.FullName!.Contains("Configurations.Write"));
+
+        modelBuilder.HasDefaultSchema("volunteer-requests");
+    }
+
+    private static ILoggerFactory CreateLoggerFactory()
+    {
+        return LoggerFactory.Create(builder => builder.AddConsole());
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/DependencyInjection.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ProjectPet.Core.Abstractions;
-using ProjectPet.VolunteerModule.Infrastructure.Database;
 using ProjectPet.VolunteerRequests.Application.Interfaces;
 using ProjectPet.VolunteerRequests.Infrastructure.Database;
 using ProjectPet.VolunteerRequests.Infrastructure.Repositories;

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/DependencyInjection.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ProjectPet.Core.Abstractions;
+using ProjectPet.VolunteerModule.Infrastructure.Database;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Infrastructure.Database;
+using ProjectPet.VolunteerRequests.Infrastructure.Repositories;
+
+namespace ProjectPet.VolunteerRequests.Infrastructure;
+public static class DependencyInjection
+{
+    public static IHostApplicationBuilder AddVolunteerRequestModuleInfrastructure(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddScoped<IReadDbContext, ReadDbContext>();
+
+        builder.Services.AddScoped<WriteDbContext>();
+
+        builder.Services.AddScoped<IVolunteerRequestRepository, VolunteerRequestRepository>();
+
+        builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+        return builder;
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/ProjectPet.VolunteerRequests.Infrastructure.csproj
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/ProjectPet.VolunteerRequests.Infrastructure.csproj
@@ -16,7 +16,13 @@
 	</ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Core\ProjectPet.Core\ProjectPet.Core.csproj" />
+    <ProjectReference Include="..\..\Core\ProjectPet.Framework\ProjectPet.Framework.csproj" />
     <ProjectReference Include="..\ProjectPet.VolunteerRequest.Application\ProjectPet.VolunteerRequests.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Migrations\" />
   </ItemGroup>
 
 </Project>

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Repositories/VolunteerRequestRepository.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Repositories/VolunteerRequestRepository.cs
@@ -1,9 +1,9 @@
 ﻿using CSharpFunctionalExtensions;
 using Microsoft.EntityFrameworkCore;
 using ProjectPet.SharedKernel.ErrorClasses;
-using ProjectPet.VolunteerModule.Infrastructure.Database;
 using ProjectPet.VolunteerRequests.Application.Interfaces;
 using ProjectPet.VolunteerRequests.Domain.Models;
+using ProjectPet.VolunteerRequests.Infrastructure.Database;
 
 namespace ProjectPet.VolunteerRequests.Infrastructure.Repositories;
 public class VolunteerRequestRepository : IVolunteerRequestRepository

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Repositories/VolunteerRequestRepository.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/Repositories/VolunteerRequestRepository.cs
@@ -1,0 +1,51 @@
+﻿using CSharpFunctionalExtensions;
+using Microsoft.EntityFrameworkCore;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerModule.Infrastructure.Database;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Domain.Models;
+
+namespace ProjectPet.VolunteerRequests.Infrastructure.Repositories;
+public class VolunteerRequestRepository : IVolunteerRequestRepository
+{
+    private readonly WriteDbContext _dbContext;
+    public VolunteerRequestRepository(WriteDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Result<Guid, Error>> AddAsync(VolunteerRequest volunteerReq, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.VolunteerRequests.AddAsync(volunteerReq, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return volunteerReq.Id;
+    }
+
+    public async Task<Result<Guid, Error>> Delete(VolunteerRequest volunteerReq, CancellationToken cancellationToken = default)
+    {
+        _dbContext.VolunteerRequests.Remove(volunteerReq);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return volunteerReq.Id;
+    }
+
+    public async Task<Result<VolunteerRequest, Error>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var result = await _dbContext.VolunteerRequests
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+
+        if (result is null)
+            return Errors.General.NotFound(typeof(VolunteerRequest), id);
+
+        return result;
+    }
+
+    public async Task<Result<Guid, Error>> Save(VolunteerRequest volunteerReq, CancellationToken cancellationToken = default)
+    {
+        _dbContext.VolunteerRequests.Attach(volunteerReq);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return volunteerReq.Id;
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/UnitOfWork.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/UnitOfWork.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Storage;
+using ProjectPet.Core.Abstractions;
+using ProjectPet.VolunteerModule.Infrastructure.Database;
+using System.Data;
+
+namespace ProjectPet.VolunteerRequests.Infrastructure;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly WriteDbContext _context;
+
+    public UnitOfWork(WriteDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+        return transaction.GetDbTransaction();
+    }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/UnitOfWork.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Infrastructure/UnitOfWork.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.Storage;
 using ProjectPet.Core.Abstractions;
-using ProjectPet.VolunteerModule.Infrastructure.Database;
+using ProjectPet.VolunteerRequests.Infrastructure.Database;
 using System.Data;
 
 namespace ProjectPet.VolunteerRequests.Infrastructure;

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/Class1.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectPet.VolunteerRequests.Presentation;
-
-public class Class1
-{
-
-}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/DependencyInjection.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/DependencyInjection.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace ProjectPet.VolunteerRequests.Presentation;
+public static class DependencyInjection
+{
+    public static IHostApplicationBuilder AddVolunteerRequestsModuleHandlers(this IHostApplicationBuilder builder)
+    {
+        return builder;
+    }
+
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/DependencyInjection.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/DependencyInjection.cs
@@ -1,11 +1,39 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Approve;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Create;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Reject;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.RequestRevision;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Review;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Update;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByUserIdPaginatedFiltered;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetUnassignedPaginated;
 
 namespace ProjectPet.VolunteerRequests.Presentation;
 public static class DependencyInjection
 {
     public static IHostApplicationBuilder AddVolunteerRequestsModuleHandlers(this IHostApplicationBuilder builder)
     {
-        return builder;
+        return builder
+            .AddVolunteerRequestsHandlers();
     }
 
+    private static IHostApplicationBuilder AddVolunteerRequestsHandlers(this IHostApplicationBuilder builder)
+    {
+        // write
+        builder.Services.AddScoped<ApproveHandler>();
+        builder.Services.AddScoped<CreateHandler>();
+        builder.Services.AddScoped<RejectHandler>();
+        builder.Services.AddScoped<RequestRevisionHandler>();
+        builder.Services.AddScoped<ReviewHandler>();
+        builder.Services.AddScoped<UpdateHandler>();
+
+        // read
+        builder.Services.AddScoped<GetByAdminIdPaginatedFilteredHandler>();
+        builder.Services.AddScoped<GetByUserIdPaginatedFilteredHandler>();
+        builder.Services.AddScoped<GetUnassignedPaginatedHandler>();
+
+        return builder;
+    }
 }

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/DependencyInjection.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Approve;
 using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Create;
@@ -16,7 +17,15 @@ public static class DependencyInjection
     public static IHostApplicationBuilder AddVolunteerRequestsModuleHandlers(this IHostApplicationBuilder builder)
     {
         return builder
-            .AddVolunteerRequestsHandlers();
+            .AddVolunteerRequestsHandlers()
+            .AddValidators();
+    }
+
+    private static IHostApplicationBuilder AddValidators(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddValidatorsFromAssemblyContaining(typeof(DependencyInjection));
+
+        return builder;
     }
 
     private static IHostApplicationBuilder AddVolunteerRequestsHandlers(this IHostApplicationBuilder builder)

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/CreateValidator.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/CreateValidator.cs
@@ -1,0 +1,32 @@
+﻿using FluentValidation;
+using ProjectPet.Core.Validator;
+using ProjectPet.SharedKernel;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Presentation.VolunteerRequests.RequestValidation;
+public class CreateValidator : AbstractValidator<CreateVolunteerRequestRequest>
+{
+    public CreateValidator()
+    {
+        RuleForEach(req => req.AccountDto.PaymentInfos)
+            .ChildRules(payInfo =>
+            {
+                payInfo.RuleFor(x => x.Instructions)
+                    .NotEmpty()
+                    .WithError(Errors.General.ValueIsEmptyOrNull)
+                    .MaxLengthWithError(Constants.STRING_LEN_MEDIUM);
+
+                payInfo.RuleFor(x => x.Title)
+                    .NotEmpty()
+                    .WithError(Errors.General.ValueIsEmptyOrNull)
+                    .MaxLengthWithError(Constants.STRING_LEN_SMALL);
+            });
+            
+        RuleForEach(req => req.AccountDto.Certifications)
+            .NotEmpty()
+            .WithError(Errors.General.ValueIsEmptyOrNull)
+            .MaxLengthWithError(Constants.STRING_LEN_MEDIUM);
+    }
+}
+

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/CreateValidator.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/CreateValidator.cs
@@ -22,7 +22,7 @@ public class CreateValidator : AbstractValidator<CreateVolunteerRequestRequest>
                     .WithError(Errors.General.ValueIsEmptyOrNull)
                     .MaxLengthWithError(Constants.STRING_LEN_SMALL);
             });
-            
+
         RuleForEach(req => req.AccountDto.Certifications)
             .NotEmpty()
             .WithError(Errors.General.ValueIsEmptyOrNull)

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/RejectValidator.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/RejectValidator.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+using ProjectPet.Core.Validator;
+using ProjectPet.SharedKernel;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Presentation.VolunteerRequests.RequestValidation;
+
+public class RejectValidator : AbstractValidator<RejectVolunteerRequestRequest>
+{
+    public RejectValidator()
+    {
+        RuleFor(req => req.RejectionComment)
+            .NotEmpty()
+            .WithError(Errors.General.ValueIsEmptyOrNull)
+            .MaxLengthWithError(Constants.STRING_LEN_MEDIUM);
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/RevisionValidator.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/RevisionValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using ProjectPet.Core.Validator;
+using ProjectPet.SharedKernel;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Presentation.VolunteerRequests.RequestValidation;
+public class RequestRevisionValidator : AbstractValidator<RequestRevisionVolunteerRequestRequest>
+{
+    public RequestRevisionValidator()
+    {
+        RuleFor(req => req.RevisionComment)
+            .NotEmpty()
+            .WithError(Errors.General.ValueIsEmptyOrNull)
+            .MaxLengthWithError(Constants.STRING_LEN_MEDIUM);
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/UpdateValidator.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/RequestValidation/UpdateValidator.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+using ProjectPet.Core.Validator;
+using ProjectPet.SharedKernel;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+namespace ProjectPet.VolunteerRequests.Presentation.VolunteerRequests.RequestValidation;
+
+public class UpdateValidator : AbstractValidator<UpdateVolunteerRequestRequest>
+{
+    public UpdateValidator()
+    {
+        RuleForEach(req => req.VolunteerAccountDto.PaymentInfos)
+            .ChildRules(payInfo =>
+            {
+                payInfo.RuleFor(x => x.Instructions)
+                    .NotEmpty()
+                    .WithError(Errors.General.ValueIsEmptyOrNull)
+                    .MaxLengthWithError(Constants.STRING_LEN_MEDIUM);
+
+                payInfo.RuleFor(x => x.Title)
+                    .NotEmpty()
+                    .WithError(Errors.General.ValueIsEmptyOrNull)
+                    .MaxLengthWithError(Constants.STRING_LEN_SMALL);
+            });
+
+        RuleForEach(req => req.VolunteerAccountDto.Certifications)
+            .NotEmpty()
+            .WithError(Errors.General.ValueIsEmptyOrNull)
+            .MaxLengthWithError(Constants.STRING_LEN_MEDIUM);
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -206,7 +206,7 @@ public class VolunteerRequestsController : CustomControllerBase
         return Ok(result.Value);
     }
 
-    private Result<Guid,Error> GetCurrentUserId()
+    private Result<Guid, Error> GetCurrentUserId()
     {
         string? userId = HttpContext.User.Claims.FirstOrDefault(u => u.Properties.Values.Contains("sub"))?.Value;
         if (String.IsNullOrWhiteSpace(userId))

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -1,0 +1,195 @@
+﻿using CSharpFunctionalExtensions;
+using Microsoft.AspNetCore.Mvc;
+using ProjectPet.Framework;
+using ProjectPet.Framework.Authorization;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Approve;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Create;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Reject;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.RequestRevision;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Review;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Update;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByUserIdPaginatedFiltered;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetUnassignedPaginated;
+using ProjectPet.VolunteerRequests.Contracts.Requests;
+
+namespace ProjectPet.VolunteerRequests.Presentation.VolunteerRequests;
+public class VolunteerRequestsController : CustomControllerBase
+{
+    [Permission(PermissionCodes.VolunteerRequestCreate)]
+    [HttpPost()]
+    public async Task<IActionResult> CreateVolunteerRequest(
+        [FromServices] CreateHandler handler,
+        [FromBody] CreateVolunteerRequestRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var userIdRes = GetCurrentUserId();
+        if (userIdRes.IsFailure)
+            return userIdRes.Error.ToResponse();
+
+        var command = CreateCommand.FromRequest(request, userIdRes.Value);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestUpdate)]
+    [HttpPut("{requestId:Guid}")]
+    public async Task<IActionResult> UpdateVolunteerRequest(
+        [FromServices] UpdateHandler handler,
+        [FromBody] UpdateVolunteerRequestRequest request,
+        [FromRoute] Guid requestId,
+        CancellationToken cancellationToken = default)
+    {
+        var command = UpdateCommand.FromRequest(request, requestId);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestAdmin)]
+    [HttpPut("{requestId:Guid}/review")]
+    public async Task<IActionResult> ReviewVolunteerRequest(
+        [FromServices] ReviewHandler handler,
+        [FromRoute] Guid requestId,
+        CancellationToken cancellationToken = default)
+    {
+        var adminIdRes = GetCurrentUserId();
+        if (adminIdRes.IsFailure)
+            return adminIdRes.Error.ToResponse();
+
+        var command = new ReviewCommand(requestId, adminIdRes.Value);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestAdmin)]
+    [HttpPut("{requestId:Guid}/request-revision")]
+    public async Task<IActionResult> RequestRevisionVolunteerRequest(
+        [FromServices] RequestRevisionHandler handler,
+        [FromBody] RequestRevisionVolunteerRequestRequest request,
+        [FromRoute] Guid requestId,
+        CancellationToken cancellationToken = default)
+    {
+        var command = RequestRevisionCommand.FromRequest(request, requestId);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestAdmin)]
+    [HttpPut("{requestId:Guid}/reject")]
+    public async Task<IActionResult> RejectVolunteerRequest(
+        [FromServices] RejectHandler handler,
+        [FromBody] RejectVolunteerRequestRequest request,
+        [FromRoute] Guid requestId,
+        CancellationToken cancellationToken = default)
+    {
+        var command = RejectCommand.FromRequest(request, requestId, PermissionCodes.VolunteerRequestCreate);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestAdmin)]
+    [HttpPut("{requestId:Guid}/approve")]
+    public async Task<IActionResult> ApproveVolunteerRequest(
+        [FromServices] ApproveHandler handler,
+        [FromRoute] Guid requestId,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new ApproveCommand(requestId);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok();
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestAdmin)]
+    [HttpGet("unassigned")]
+    public async Task<IActionResult> GetUnassignedVolunteerRequestsPaginated(
+        [FromServices] GetUnassignedPaginatedHandler handler,
+        [FromQuery] GetVolunteerRequestsPaginatedRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var query = GetUnassignedPaginatedQuery.FromRequest(request);
+        var result = await handler.HandleAsync(query, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestAdmin)]
+    [HttpGet("byadmin/{adminId:Guid?}")]
+    public async Task<IActionResult> GetVolunteerRequestsByAdminId(
+        [FromServices] GetByAdminIdPaginatedFilteredHandler handler,
+        [FromQuery] GetVolunteerRequestFilteredPaginatedRequest request,
+        [FromQuery] Guid? adminId,
+        CancellationToken cancellationToken = default)
+    {
+        if (adminId is null || Equals(adminId, Guid.Empty))
+        {
+            var getAdminIdRes = GetCurrentUserId();
+            if (getAdminIdRes.IsFailure)
+                return getAdminIdRes.Error.ToResponse();
+            adminId = getAdminIdRes.Value;
+        }
+
+        var query = GetByAdminIdPaginatedFilteredQuery.FromRequest(request, (Guid)adminId);
+        var result = await handler.HandleAsync(query, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    [Permission(PermissionCodes.VolunteerRequestRead)]
+    [HttpGet("byuser")]
+    public async Task<IActionResult> GetVolunteerRequestsByUserId(
+        [FromServices] GetByUserIdPaginatedFilteredHandler handler,
+        [FromQuery] GetVolunteerRequestFilteredPaginatedRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var getUserIdRes = GetCurrentUserId();
+        if (getUserIdRes.IsFailure)
+            return getUserIdRes.Error.ToResponse();
+
+        var query = GetByUserIdPaginatedFilteredQuery.FromRequest(request, getUserIdRes.Value);
+        var result = await handler.HandleAsync(query, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error.ToResponse();
+
+        return Ok(result.Value);
+    }
+
+    private Result<Guid,Error> GetCurrentUserId()
+    {
+        string? userId = HttpContext.User.Claims.FirstOrDefault(u => u.Properties.Values.Contains("sub"))?.Value;
+        if (String.IsNullOrWhiteSpace(userId))
+            return Error.Failure("claim.not.found", "Unknown user!");
+        return new Guid(userId);
+    }
+}

--- a/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/src/VolunteerRequest/ProjectPet.VolunteerRequest.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -1,4 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using ProjectPet.Framework;
 using ProjectPet.Framework.Authorization;
@@ -21,9 +22,14 @@ public class VolunteerRequestsController : CustomControllerBase
     [HttpPost()]
     public async Task<IActionResult> CreateVolunteerRequest(
         [FromServices] CreateHandler handler,
+        IValidator<CreateVolunteerRequestRequest> validator,
         [FromBody] CreateVolunteerRequestRequest request,
         CancellationToken cancellationToken = default)
     {
+        var validatorRes = await validator.ValidateAsync(request, cancellationToken);
+        if (validatorRes.IsValid == false)
+            return Envelope.ToResponse(validatorRes.Errors);
+
         var userIdRes = GetCurrentUserId();
         if (userIdRes.IsFailure)
             return userIdRes.Error.ToResponse();
@@ -42,9 +48,14 @@ public class VolunteerRequestsController : CustomControllerBase
     public async Task<IActionResult> UpdateVolunteerRequest(
         [FromServices] UpdateHandler handler,
         [FromBody] UpdateVolunteerRequestRequest request,
+        IValidator<UpdateVolunteerRequestRequest> validator,
         [FromRoute] Guid requestId,
         CancellationToken cancellationToken = default)
     {
+        var validatorRes = await validator.ValidateAsync(request, cancellationToken);
+        if (validatorRes.IsValid == false)
+            return Envelope.ToResponse(validatorRes.Errors);
+
         var command = UpdateCommand.FromRequest(request, requestId);
         var result = await handler.HandleAsync(command, cancellationToken);
 
@@ -79,9 +90,14 @@ public class VolunteerRequestsController : CustomControllerBase
     public async Task<IActionResult> RequestRevisionVolunteerRequest(
         [FromServices] RequestRevisionHandler handler,
         [FromBody] RequestRevisionVolunteerRequestRequest request,
+        IValidator<RequestRevisionVolunteerRequestRequest> validator,
         [FromRoute] Guid requestId,
         CancellationToken cancellationToken = default)
     {
+        var validatorRes = await validator.ValidateAsync(request, cancellationToken);
+        if (validatorRes.IsValid == false)
+            return Envelope.ToResponse(validatorRes.Errors);
+
         var command = RequestRevisionCommand.FromRequest(request, requestId);
         var result = await handler.HandleAsync(command, cancellationToken);
 
@@ -97,8 +113,13 @@ public class VolunteerRequestsController : CustomControllerBase
         [FromServices] RejectHandler handler,
         [FromBody] RejectVolunteerRequestRequest request,
         [FromRoute] Guid requestId,
+        IValidator<RejectVolunteerRequestRequest> validator,
         CancellationToken cancellationToken = default)
     {
+        var validatorRes = await validator.ValidateAsync(request, cancellationToken);
+        if (validatorRes.IsValid == false)
+            return Envelope.ToResponse(validatorRes.Errors);
+
         var command = RejectCommand.FromRequest(request, requestId, PermissionCodes.VolunteerRequestCreate);
         var result = await handler.HandleAsync(command, cancellationToken);
 

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequest.UnitTests/VolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequest.UnitTests/VolunteerRequestTests.cs
@@ -3,6 +3,7 @@ using CSharpFunctionalExtensions;
 using FluentAssertions;
 using ProjectPet.SharedKernel.ErrorClasses;
 using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.SharedKernel.ValueObjects;
 using ProjectPet.VolunteerRequests.Domain.Models;
 
 namespace ProjectPet.VolunteerRequests.UnitTests;
@@ -20,7 +21,7 @@ public class VolunteerRequestTests
     public void NewRequest_StateEqualsTo_Submitted()
     {
         // arrange
-        var accountDto = _fixture.Create<VolunteerAccountDto>();
+        var accountDto = _fixture.Create<VolunteerAccount>();
 
         // act
         var sut = VolunteerRequest.Create(
@@ -105,12 +106,12 @@ public class VolunteerRequestTests
     private VolunteerRequest CreateVolunteerRequest(
         Guid userId = default,
         Guid discussionId = default,
-        VolunteerAccountDto dto = null!)
+        VolunteerAccount volunteerAccount = null!)
     {
         var createResult = VolunteerRequest.Create(
             userId == default ?         Guid.NewGuid() : userId,
             discussionId == default ?   Guid.NewGuid() : discussionId,
-            dto ??                      _fixture.Create<VolunteerAccountDto>());
+            volunteerAccount ??                      _fixture.Create<VolunteerAccount>());
 
         return createResult.Value;
     }

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequest.UnitTests/VolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequest.UnitTests/VolunteerRequestTests.cs
@@ -2,8 +2,6 @@ using AutoFixture;
 using CSharpFunctionalExtensions;
 using FluentAssertions;
 using ProjectPet.SharedKernel.ErrorClasses;
-using ProjectPet.SharedKernel.SharedDto;
-using ProjectPet.SharedKernel.ValueObjects;
 using ProjectPet.VolunteerRequests.Domain.Models;
 
 namespace ProjectPet.VolunteerRequests.UnitTests;
@@ -21,7 +19,7 @@ public class VolunteerRequestTests
     public void NewRequest_StateEqualsTo_Submitted()
     {
         // arrange
-        var accountDto = _fixture.Create<VolunteerAccount>();
+        var accountDto = _fixture.Create<VolunteerAccountData>();
 
         // act
         var sut = VolunteerRequest.Create(
@@ -106,12 +104,12 @@ public class VolunteerRequestTests
     private VolunteerRequest CreateVolunteerRequest(
         Guid userId = default,
         Guid discussionId = default,
-        VolunteerAccount volunteerAccount = null!)
+        VolunteerAccountData volunteerAccount = null!)
     {
         var createResult = VolunteerRequest.Create(
-            userId == default ?         Guid.NewGuid() : userId,
-            discussionId == default ?   Guid.NewGuid() : discussionId,
-            volunteerAccount ??                      _fixture.Create<VolunteerAccount>());
+            userId == default ? Guid.NewGuid() : userId,
+            discussionId == default ? Guid.NewGuid() : discussionId,
+            volunteerAccount ?? _fixture.Create<VolunteerAccountData>());
 
         return createResult.Value;
     }

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/IntegrationTestWebFactoryBase.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/IntegrationTestWebFactoryBase.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using ProjectPet.AccountsModule.Infrastructure.Seeding;
+using Respawn;
+using Respawn.Graph;
+using System.Data.Common;
+using Testcontainers.PostgreSql;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+abstract public class IntegrationTestWebFactoryBase : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private const string DB_CONNECTION_STRING_KEY = "CStrings:Postgresql";
+
+    private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder()
+        .WithImage("postgres")
+        .WithDatabase("project_pet_tests")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    private Respawner _respawner = default!;
+    private DbConnection _dbConnection = default!;
+
+    public virtual async Task InitializeAsync()
+    {
+        await _dbContainer.StartAsync();
+        _dbConnection = new NpgsqlConnection(_dbContainer.GetConnectionString());
+        using var scope = Services.CreateScope();
+
+        await InitializeDbContexts(scope);
+        await SeedRoles(scope.ServiceProvider);
+        await InitializeRespawner();
+    }
+
+    protected async Task SeedRoles(IServiceProvider provider)
+    {
+        var seeder = (DatabaseAccountsSeeder)ActivatorUtilities.CreateInstance(provider, typeof(DatabaseAccountsSeeder));
+        await seeder.SeedAsync();
+    }
+
+    private async Task InitializeDbContexts(IServiceScope scope)
+    {
+        var dbCreators = IncludedDBContextsAndSchemas()
+            .Select(x => x.DbContextType)
+            .DbContextTypeToCreator(scope);
+
+        bool firstDbContext = true;
+        foreach (var dbCreator in dbCreators)
+        {
+            if (firstDbContext)
+            {
+                firstDbContext = false;
+                await dbCreator.EnsureDeletedAsync();
+                await dbCreator.EnsureCreatedAsync();
+                continue;
+            }
+
+            await dbCreator.CreateTablesAsync();
+        }
+    }
+
+    private async Task InitializeRespawner()
+    {
+        await _dbConnection.OpenAsync();
+        _respawner = await Respawner.CreateAsync(_dbConnection, new RespawnerOptions
+        {
+            TablesToIgnore = new Table[]
+            {
+                "permissions",
+                "role_permissions",
+                "roles",
+            },
+            DbAdapter = DbAdapter.Postgres,
+            SchemasToInclude = IncludedDBContextsAndSchemas().Select(x => x.Schema).ToArray(),
+        });
+    }
+
+    abstract protected IEnumerable<(Type DbContextType, string Schema)> IncludedDBContextsAndSchemas();
+
+    public async Task ResetDatabaseAsync()
+    {
+        await _respawner.ResetAsync(_dbConnection);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureTestServices(ConfigureServices);
+        builder.ConfigureAppConfiguration(ConfigureConfigs);
+    }
+
+    private void ConfigureConfigs(WebHostBuilderContext context, IConfigurationBuilder builder)
+    {
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [DB_CONNECTION_STRING_KEY] = _dbContainer.GetConnectionString()
+        });
+    }
+
+    protected virtual void ConfigureServices(IServiceCollection services) { }
+
+    new public async Task DisposeAsync()
+    {
+        await _dbContainer.StopAsync();
+        await _dbContainer.DisposeAsync();
+        await base.DisposeAsync();
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/TestExpansions.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/TestExpansions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+public static class TestExpansions
+{
+    public static IEnumerable<RelationalDatabaseCreator> DbContextTypeToCreator(
+        this IEnumerable<Type> types,
+        IServiceScope scope)
+    {
+        foreach (var type in types)
+            yield return (RelationalDatabaseCreator)
+                            ((DbContext)
+                                (scope.ServiceProvider.GetRequiredService(type)))
+                                    .Database.GetService<IDatabaseCreator>();
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/VolunteerRequestsWebFactory.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/VolunteerRequestsWebFactory.cs
@@ -1,5 +1,4 @@
-﻿using CSharpFunctionalExtensions;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
 using ProjectPet.AccountsModule.Contracts;

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/VolunteerRequestsWebFactory.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/Factories/VolunteerRequestsWebFactory.cs
@@ -1,0 +1,75 @@
+﻿using CSharpFunctionalExtensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+using ProjectPet.AccountsModule.Contracts;
+using ProjectPet.AccountsModule.Infrastructure.Database;
+using ProjectPet.Core.Abstractions;
+using ProjectPet.DiscussionsModule.Contracts;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.VolunteerRequests.IntegrationTests.ToggleMocks;
+using DiscussionsWriteDbContext = ProjectPet.DiscussionsModule.Infrastructure.Database.WriteDbContext;
+using VolunteerWriteDbContext = ProjectPet.VolunteerRequests.Infrastructure.Database.WriteDbContext;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+public class VolunteerRequestsWebFactory : IntegrationTestWebFactoryBase
+{
+    protected DiscussionModuleContractToggleMock _discussionModuleContractMock = new DiscussionModuleContractToggleMock();
+    protected AccountsModuleContractToggleMock _accountModuleContractMock = new AccountsModuleContractToggleMock();
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.RemoveAll<IDatabaseSeeder>();
+        services.Replace(ServiceDescriptor.Scoped(typeof(IDiscussionModuleContract), _ => _discussionModuleContractMock));
+        services.Replace(ServiceDescriptor.Scoped(typeof(IAccountsModuleContract), _ => _accountModuleContractMock));
+        base.ConfigureServices(services);
+    }
+
+    protected override IEnumerable<(Type DbContextType, string Schema)> IncludedDBContextsAndSchemas()
+        => [
+            (typeof(VolunteerWriteDbContext), "volunteer-requests"),
+            (typeof(DiscussionsWriteDbContext), "discussion-module"),
+            (typeof(AuthDbContext), "auth")
+           ];
+
+    #region Mock methods
+    public void SetMockProviders(IServiceProvider provider)
+    {
+        _discussionModuleContractMock.SetProvider(provider);
+        _accountModuleContractMock.SetProvider(provider);
+    }
+
+    public void ResetMocks()
+    {
+        _discussionModuleContractMock.Reset();
+        _accountModuleContractMock.Reset();
+    }
+
+    public Error IDiscussionModuleContractMock_CreateDiscussionAsync_Failure()
+    {
+        var error = Error.Failure("debug.fail", "debugfail");
+
+        _discussionModuleContractMock.MockFunction(nameof(IDiscussionModuleContract.CreateDiscussionAsync));
+        _discussionModuleContractMock.Mock
+            .CreateDiscussionAsync(
+                Arg.Any<Guid>(), Arg.Any<IEnumerable<Guid>>()
+            )
+            .Returns(error);
+        return error;
+    }
+
+    public Error IAccountsModuleContract_MakeUserVolunteerAsync_Failure()
+    {
+        var error = Error.Failure("debug.fail", "debugfail");
+
+        _accountModuleContractMock.MockFunction(nameof(IAccountsModuleContract.MakeUserVolunteerAsync));
+        _accountModuleContractMock.Mock
+            .MakeUserVolunteerAsync(
+                Arg.Any<Guid>(), Arg.Any<VolunteerAccountDto>(), Arg.Any<CancellationToken>()
+            )
+            .Returns(error);
+        return error;
+    }
+    #endregion
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ProjectPet.VolunteerRequests.IntegrationTests.csproj
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ProjectPet.VolunteerRequests.IntegrationTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Respawn" Version="6.2.1" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
+  </ItemGroup>
+
+	<ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\ProjectPet.Web\ProjectPet.Web.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/AccountsModuleContractToggleMock.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/AccountsModuleContractToggleMock.cs
@@ -1,0 +1,26 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.AccountsModule.Application;
+using ProjectPet.AccountsModule.Contracts;
+using ProjectPet.AccountsModule.Contracts.Dto;
+using ProjectPet.SharedKernel.ErrorClasses;
+using ProjectPet.SharedKernel.SharedDto;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.ToggleMocks;
+public class AccountsModuleContractToggleMock : ToggleMockBase<IAccountsModuleContract, AccountsModuleContractImplementation>, IAccountsModuleContract
+{
+    public async Task<Result<Guid, Error>> CreatePermissionModifierAsync(Guid userId, PermissionModifierDto modifierDto, CancellationToken ctoken = default)
+    {
+        if (IsMocked(nameof(CreatePermissionModifierAsync)))
+            return await Mock.CreatePermissionModifierAsync(userId, modifierDto, ctoken);
+        else
+            return await CreateInstance().CreatePermissionModifierAsync(userId, modifierDto, ctoken);
+    }
+
+    public async Task<UnitResult<Error>> MakeUserVolunteerAsync(Guid userId, VolunteerAccountDto accountDto, CancellationToken ctoken = default)
+    {
+        if (IsMocked(nameof(MakeUserVolunteerAsync)))
+            return await Mock.MakeUserVolunteerAsync(userId, accountDto, ctoken);
+        else
+            return await CreateInstance().MakeUserVolunteerAsync(userId, accountDto, ctoken);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/DiscussionModuleContractToggleMock.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/DiscussionModuleContractToggleMock.cs
@@ -1,0 +1,16 @@
+﻿using CSharpFunctionalExtensions;
+using ProjectPet.DiscussionsModule.Application;
+using ProjectPet.DiscussionsModule.Contracts;
+using ProjectPet.SharedKernel.ErrorClasses;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.ToggleMocks;
+public class DiscussionModuleContractToggleMock : ToggleMockBase<IDiscussionModuleContract, DiscussionModuleContractImplementation>, IDiscussionModuleContract
+{
+    public Task<Result<Guid, Error>> CreateDiscussionAsync(Guid relatedEntityId, IEnumerable<Guid> participantUserIds)
+    {
+        if (IsMocked(nameof(CreateDiscussionAsync)))
+            return Mock.CreateDiscussionAsync(relatedEntityId, participantUserIds);
+        else
+            return CreateInstance().CreateDiscussionAsync(relatedEntityId, participantUserIds);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/ToggleMockBase.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/ToggleMockBase.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NSubstitute.ClearExtensions;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 
 public abstract class ToggleMockBase<TInterface, TImplementation>
     where TInterface : class

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/ToggleMockBase.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/ToggleMocks/ToggleMockBase.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ClearExtensions;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+
+public abstract class ToggleMockBase<TInterface, TImplementation>
+    where TInterface : class
+    where TImplementation : class, TInterface
+{
+    private HashSet<string> _mockedFunctionNames = new();
+
+    public TInterface Mock { get; protected set; }
+    public IServiceProvider ServiceProvider { get; private set; } = null!;
+
+    protected ToggleMockBase()
+    {
+        Mock = Substitute.For<TInterface>();
+    }
+
+    public void SetProvider(IServiceProvider serviceProvider)
+    {
+        ServiceProvider = serviceProvider;
+    }
+
+    public void MockFunction(string nameOfFunction)
+    {
+        _mockedFunctionNames.Add(nameOfFunction);
+    }
+
+    public void Reset()
+    {
+        Mock.ClearSubstitute();
+        _mockedFunctionNames.Clear();
+    }
+
+    protected bool IsMocked(string functionName)
+        => _mockedFunctionNames.Contains(functionName);
+
+    protected TInterface CreateInstance()
+        => (TImplementation)ActivatorUtilities.CreateInstance(ServiceProvider, typeof(TImplementation));
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Base/VolunteerRequestsTestBase.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Base/VolunteerRequestsTestBase.cs
@@ -1,6 +1,5 @@
 ﻿using AutoFixture;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectPet.AccountsModule.Domain;
 using ProjectPet.AccountsModule.Domain.Accounts;
@@ -92,7 +91,7 @@ public class VolunteerRequestsTestBase : IClassFixture<VolunteerRequestsWebFacto
         adminId ??= _fixture.Create<Guid>();
         userId ??= _fixture.Create<Guid>();
 
-        var volunteerRequest = await SeedVolunteerRequestAsync((Guid)userId, x => 
+        var volunteerRequest = await SeedVolunteerRequestAsync((Guid)userId, x =>
         {
             x.BeginReview((Guid)adminId);
             x.RequestRevision("revision-required");

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Base/VolunteerRequestsTestBase.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Base/VolunteerRequestsTestBase.cs
@@ -1,0 +1,115 @@
+﻿using AutoFixture;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.AccountsModule.Domain;
+using ProjectPet.AccountsModule.Domain.Accounts;
+using ProjectPet.AccountsModule.Infrastructure.Database;
+using ProjectPet.VolunteerRequests.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Domain.Models;
+using ProjectPet.VolunteerRequests.Infrastructure.Database;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+public class VolunteerRequestsTestBase : IClassFixture<VolunteerRequestsWebFactory>, IAsyncLifetime
+{
+    protected readonly Fixture _fixture;
+    protected readonly IReadDbContext _readDbContext;
+    protected readonly WriteDbContext _writeDbContext;
+    protected readonly AuthDbContext _authDbContext;
+    protected readonly UserManager<User> _userManager;
+    protected readonly VolunteerRequestsWebFactory _factory;
+    protected readonly IServiceScope _serviceScope;
+    public VolunteerRequestsTestBase(VolunteerRequestsWebFactory factory)
+    {
+        _factory = factory;
+        _serviceScope = _factory.Services.CreateScope();
+        _fixture = new Fixture();
+        _readDbContext = _serviceScope.ServiceProvider.GetRequiredService<IReadDbContext>();
+        _writeDbContext = _serviceScope.ServiceProvider.GetRequiredService<WriteDbContext>();
+        _authDbContext = _serviceScope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        _userManager = _serviceScope.ServiceProvider.GetRequiredService<UserManager<User>>();
+
+        _factory.SetMockProviders(_serviceScope.ServiceProvider);
+        SetupFixtures();
+    }
+
+    public Task InitializeAsync()
+        => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        _factory.ResetMocks();
+        _serviceScope.Dispose();
+        await _factory.ResetDatabaseAsync();
+    }
+
+    #region Data generation
+
+    private void SetupFixtures()
+    {
+        //_fixture.Register(() => new PhonenumberDto("123-456-78-99", "+4"));
+        //_fixture.Register<Stream>(() => new MemoryStream(Encoding.UTF8.GetBytes("whatever")));
+    }
+
+    protected async Task<User> SeedUserAsync()
+    {
+        var user = await User.CreateMemberAsync(
+            _userManager,
+            _fixture.Create<string>(),
+            $"A{_fixture.Create<string>()}123#",
+            $"{_fixture.Create<string>()}@mail.com",
+            _fixture.Create<MemberAccount>()
+            );
+
+        return user.Value;
+    }
+
+    protected async Task<VolunteerRequest> SeedVolunteerRequestAsync(Guid userId = default, Action<VolunteerRequest> action = null!)
+    {
+        var volunteerReq = CreateVolunteerRequest(userId);
+
+        action?.Invoke(volunteerReq);
+
+        await _writeDbContext.VolunteerRequests.AddAsync(volunteerReq);
+        await _writeDbContext.SaveChangesAsync();
+        return volunteerReq;
+    }
+    protected async Task<VolunteerRequest> SeedVolunteerRequestAndSetToReview(Guid? adminId, Guid? userId)
+    {
+        adminId ??= _fixture.Create<Guid>();
+        userId ??= _fixture.Create<Guid>();
+
+        var volunteerRequest = await SeedVolunteerRequestAsync((Guid)userId, x => x.BeginReview((Guid)adminId));
+
+        await _writeDbContext.SaveChangesAsync();
+
+        return volunteerRequest;
+    }
+
+    protected async Task<VolunteerRequest> SeedVolunteerRequestAndSetToRevisionRequired(Guid? adminId, Guid? userId)
+    {
+        adminId ??= _fixture.Create<Guid>();
+        userId ??= _fixture.Create<Guid>();
+
+        var volunteerRequest = await SeedVolunteerRequestAsync((Guid)userId, x => 
+        {
+            x.BeginReview((Guid)adminId);
+            x.RequestRevision("revision-required");
+        });
+
+        await _writeDbContext.SaveChangesAsync();
+
+        return volunteerRequest;
+    }
+
+    private VolunteerRequest CreateVolunteerRequest(Guid userId = default)
+    {
+        return VolunteerRequest.Create(
+            userId == default ? _fixture.Create<Guid>() : userId,
+            _fixture.Create<Guid>(),
+            _fixture.Create<VolunteerAccountData>()
+        ).Value;
+    }
+    #endregion
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/ApproveVolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/ApproveVolunteerRequestTests.cs
@@ -1,5 +1,4 @@
-﻿using AutoFixture;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectPet.AccountsModule.Domain.Accounts;

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/ApproveVolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/ApproveVolunteerRequestTests.cs
@@ -1,0 +1,85 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.AccountsModule.Domain.Accounts;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Approve;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Commands;
+public class ApproveVolunteerRequestTests : VolunteerRequestsTestBase
+{
+    protected ApproveHandler _sut;
+
+    public ApproveVolunteerRequestTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<ApproveHandler>();
+    }
+
+    [Fact]
+    public async Task Approve_VolunteerRequest_Success()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var volunteerRequest = await SeedVolunteerRequestAndSetToReview(null, user.Id);
+
+        var cmd = new ApproveCommand(volunteerRequest.Id);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var volunteerRequestAssert = await _readDbContext.VolunteerRequests.AsNoTracking().FirstOrDefaultAsync();
+
+        // request status is set to approved
+        volunteerRequestAssert!.Status.Should().Be(VolunteerRequestStatusDto.approved);
+
+        // volunteer data is created for user
+        user.VolunteerData.Should().NotBeNull();
+
+        // volunteer role is set for user, user still has member role
+        var roles = await _userManager.GetRolesAsync(user);
+        roles.Should().HaveCount(2);
+        roles.Should().Contain(MemberAccount.ROLENAME);
+        roles.Should().Contain(VolunteerAccount.ROLENAME);
+    }
+
+    [Fact]
+    public async Task Approve_VolunteerRequest_CreateVolunteerAccountFailure_RequestUnchanged()
+    {
+        // Arrange
+        _factory.IAccountsModuleContract_MakeUserVolunteerAsync_Failure();
+
+        var user = await SeedUserAsync();
+        var volunteerRequest = await SeedVolunteerRequestAndSetToReview(default, user.Id);
+
+        var initialStatus = volunteerRequest!.Status;
+
+        var cmd = new ApproveCommand(volunteerRequest.Id);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+
+        var volunteerRequestAssert = await _readDbContext.VolunteerRequests.FirstOrDefaultAsync();
+
+        // request status is unchanged
+        volunteerRequestAssert!.Status.Should().Be((VolunteerRequestStatusDto)initialStatus);
+
+        // volunteer data is not created
+        user.VolunteerData.Should().BeNull();
+
+        // volunteer role is unset set for user
+        var roles = await _userManager.GetRolesAsync(user);
+        roles.Should().HaveCount(1);
+        roles.Should().Contain(MemberAccount.ROLENAME);
+        roles.Should().NotContain(VolunteerAccount.ROLENAME);
+    }
+}
+

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/CreateVolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/CreateVolunteerRequestTests.cs
@@ -1,0 +1,40 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Create;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Commands;
+public class CreateVolunteerRequestTests : VolunteerRequestsTestBase
+{
+    private CreateHandler _sut;
+
+    public CreateVolunteerRequestTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<CreateHandler>();
+    }
+
+    [Fact]
+    public async Task Create_VolunteerRequest_Success()
+    {
+        // Arrange
+        var accountDto = _fixture.Create<VolunteerAccountDto>();
+        var userId = _fixture.Create<Guid>();
+
+        var cmd = new CreateCommand(accountDto, userId);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var volunteerRequestAssert = await _readDbContext.VolunteerRequests.FirstOrDefaultAsync();
+
+        volunteerRequestAssert.Should().NotBeNull();
+        volunteerRequestAssert!.UserId.Should().Be(userId);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/RejectVolunteerRequest.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/RejectVolunteerRequest.cs
@@ -1,8 +1,6 @@
-﻿using AutoFixture;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using ProjectPet.AccountsModule.Domain;
 using ProjectPet.Framework.Authorization;
 using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Reject;
 using ProjectPet.VolunteerRequests.Contracts.Dto;

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/RejectVolunteerRequest.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/RejectVolunteerRequest.cs
@@ -1,0 +1,48 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.AccountsModule.Domain;
+using ProjectPet.Framework.Authorization;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Reject;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Commands;
+public class RejectVolunteerRequest : VolunteerRequestsTestBase
+{
+    protected RejectHandler _sut;
+
+    public RejectVolunteerRequest(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<RejectHandler>();
+    }
+
+    [Fact]
+    public async Task Reject_VolunteerRequest__Success()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var volunteerRequest = await SeedVolunteerRequestAndSetToReview(default, user.Id);
+
+        var rejectMsg = "rejected";
+
+        var cmd = new RejectCommand(rejectMsg, volunteerRequest.Id, PermissionCodes.VolunteerRequestCreate);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var volunteerRequestAssert = await _readDbContext.VolunteerRequests.FirstOrDefaultAsync();
+
+        volunteerRequestAssert!.Status.Should().Be(VolunteerRequestStatusDto.rejected);
+        volunteerRequestAssert.RejectionComment.Should().BeEquivalentTo(rejectMsg);
+
+        var permissionMod = _authDbContext.PermissionModifiers.FirstOrDefault();
+        permissionMod!.UserId.Should().Be(user.Id);
+        permissionMod!.Code.Should().Be(PermissionCodes.VolunteerRequestCreate);
+        permissionMod!.IsAllowed.Should().BeFalse();
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/RequestRevisionVolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/RequestRevisionVolunteerRequestTests.cs
@@ -1,0 +1,40 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.RequestRevision;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Commands;
+public class RequestRevisionVolunteerRequestTests : VolunteerRequestsTestBase
+{
+    private RequestRevisionHandler _sut;
+
+    public RequestRevisionVolunteerRequestTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<RequestRevisionHandler>();
+    }
+
+    [Fact]
+    public async Task VolunteerRequest_RequestRevision_Success()
+    {
+        // Arrange
+        var volunteerRequest = await SeedVolunteerRequestAsync();
+        var adminId = _fixture.Create<Guid>();
+        volunteerRequest.BeginReview(adminId);
+
+        var revisionMsg = "rejected";
+        var cmd = new RequestRevisionCommand(revisionMsg, volunteerRequest.Id);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var volunteerRequestAssert = await _readDbContext.VolunteerRequests.FirstOrDefaultAsync();
+        volunteerRequestAssert!.Status.Should().Be(VolunteerRequestStatusDto.revisionRequired);
+        volunteerRequestAssert.RejectionComment.Should().BeEquivalentTo(revisionMsg);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/ToReviewVolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/ToReviewVolunteerRequestTests.cs
@@ -1,0 +1,74 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.DiscussionsModule.Application.Interfaces;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Review;
+using ProjectPet.VolunteerRequests.Domain.Models;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Commands;
+public class ToReviewVolunteerRequestTests : VolunteerRequestsTestBase
+{
+    protected ReviewHandler _sut;
+    protected IReadDbContext _discussionsReadDbContext;
+
+    public ToReviewVolunteerRequestTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<ReviewHandler>();
+        _discussionsReadDbContext = _serviceScope.ServiceProvider.GetRequiredService<IReadDbContext>();
+    }
+
+    [Fact]
+    public async Task VolunteerRequest_ToReview__Success()
+    {
+        // Arrange
+        var volunteerRequest = await SeedVolunteerRequestAsync();
+        var adminId = _fixture.Create<Guid>();
+
+        var cmd = new ReviewCommand(volunteerRequest.Id, adminId);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        var discussion = await _discussionsReadDbContext.Discussions.FirstOrDefaultAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        volunteerRequest.Status.Should().Be(VolunteerRequestStatus.onReview);
+        discussion.Should().NotBeNull();
+        discussion.UserIds.Should().Contain(adminId);
+        discussion.UserIds.Should().Contain(volunteerRequest.UserId);
+        discussion.UserIds.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task VolunteerRequest_ToReview_DiscussionContractFailure_RequestNotCreated()
+    {
+        // Arrange
+        _factory.IDiscussionModuleContractMock_CreateDiscussionAsync_Failure();
+
+        var volunteerRequest = await SeedVolunteerRequestAsync();
+        var initialStatus = volunteerRequest.Status;
+        var adminId = _fixture.Create<Guid>();
+
+        var cmd = new ReviewCommand(volunteerRequest.Id, adminId);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        var discussion = await _discussionsReadDbContext.Discussions.FirstOrDefaultAsync();
+
+        result.IsSuccess.Should().BeFalse();
+
+        volunteerRequest.Status.Should().Be(initialStatus);
+        discussion.Should().BeNull();
+    }
+
+    //[Fact]
+    //public async Task VolunteerRequest_ToReview_RequestCreationFailure_DiscussionIsNotCreated()
+    // if domain method would fail, then this will cover that case (error in not doing both db changes though transaction)
+
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/UpdateVolunteerRequestTests.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Commands/UpdateVolunteerRequestTests.cs
@@ -1,0 +1,48 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.SharedKernel.SharedDto;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Commands.Update;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Commands;
+public class UpdateVolunteerRequestTests : VolunteerRequestsTestBase
+{
+    protected UpdateHandler _sut;
+
+    public UpdateVolunteerRequestTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<UpdateHandler>();
+    }
+
+    [Fact]
+    public async Task Update_VolunteerRequest_Success()
+    {
+        // Arrange
+        var volunteerRequest = await SeedVolunteerRequestAndSetToRevisionRequired(default, default);
+
+        var oldVolunteerData = volunteerRequest.VolunteerData;
+        var newVolunteerData = _fixture.Create<VolunteerAccountDto>();
+
+        var cmd = new UpdateCommand(volunteerRequest.Id, newVolunteerData);
+
+        // Act
+        var result = await _sut.HandleAsync(cmd, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var volunteerRequestAssert = await _readDbContext.VolunteerRequests.FirstOrDefaultAsync();
+
+        // request status is on review
+        volunteerRequestAssert!.Status.Should().Be(VolunteerRequestStatusDto.onReview);
+
+        // volunteer data is new
+        volunteerRequestAssert.VolunteerData.Certifications.Should().BeEquivalentTo(newVolunteerData.Certifications);
+        volunteerRequestAssert.VolunteerData.Experience.Should().Be(newVolunteerData.Experience);
+        volunteerRequestAssert.VolunteerData.PaymentInfos.Should().BeEquivalentTo(newVolunteerData.PaymentInfos);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByAdminId.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByAdminId.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
-using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
-using AutoFixture;
+﻿using AutoFixture;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
 using ProjectPet.VolunteerRequests.Contracts.Dto;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
 
 namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Queries;
 public class GetByAdminId : VolunteerRequestsTestBase

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByAdminId.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByAdminId.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+using AutoFixture;
+using FluentAssertions;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByAdminIdPaginatedFiltered;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Queries;
+public class GetByAdminId : VolunteerRequestsTestBase
+{
+    protected GetByAdminIdPaginatedFilteredHandler _sut;
+
+    public GetByAdminId(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<GetByAdminIdPaginatedFilteredHandler>();
+    }
+
+    [Fact]
+    public async Task GetByAdmin_NoFilter_DefaultFilter()
+    {
+        // Arrange
+        var admin1Id = _fixture.Create<Guid>();
+        var admin2Id = _fixture.Create<Guid>();
+        var volunteer1Admin1 = await SeedVolunteerRequestAndSetToReview(admin1Id, default);
+        var volunteer2Admin1 = await SeedVolunteerRequestAndSetToRevisionRequired(admin1Id, default);
+
+        var volunteer2Admin2 = await SeedVolunteerRequestAndSetToReview(admin2Id, default);
+
+        var volunteer3AdminNONE = await SeedVolunteerRequestAsync();
+
+        var query = new GetByAdminIdPaginatedFilteredQuery(admin1Id, new(null)) { Page = 0, RecordAmount = 99 };
+
+        // Act
+        var result = await _sut.HandleAsync(query, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var data = result.Value.Data;
+
+        data.Should().HaveCount(1);
+        data.Should().Contain(x => x.Id == volunteer1Admin1.Id);
+        data.Should().Contain(x => x.Status == VolunteerRequestStatusDto.onReview);
+    }
+
+    [Fact]
+    public async Task GetByAdmin_Filter_Works()
+    {
+        // Arrange
+        var admin1Id = _fixture.Create<Guid>();
+        var admin2Id = _fixture.Create<Guid>();
+        var volunteer1Admin1 = await SeedVolunteerRequestAndSetToReview(admin1Id, default);
+        var volunteer2Admin1 = await SeedVolunteerRequestAndSetToRevisionRequired(admin1Id, default);
+
+        var volunteer2Admin2 = await SeedVolunteerRequestAndSetToReview(admin2Id, default);
+
+        var volunteer3AdminNONE = await SeedVolunteerRequestAsync();
+
+        var query = new GetByAdminIdPaginatedFilteredQuery(admin1Id, new(VolunteerRequestStatusDto.revisionRequired)) { Page = 0, RecordAmount = 99 };
+
+        // Act
+        var result = await _sut.HandleAsync(query, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var data = result.Value.Data;
+
+        data.Should().HaveCount(1);
+        data.Should().Contain(x => x.Id == volunteer2Admin1.Id);
+        data.Should().Contain(x => x.Status == VolunteerRequestStatusDto.revisionRequired);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByUserId.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByUserId.cs
@@ -1,10 +1,8 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using ProjectPet.AccountsModule.Domain;
 using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByUserIdPaginatedFiltered;
 using ProjectPet.VolunteerRequests.Contracts.Dto;
-using ProjectPet.VolunteerRequests.Domain.Models;
 using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
 using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
 

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByUserId.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetByUserId.cs
@@ -1,0 +1,64 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.AccountsModule.Domain;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetByUserIdPaginatedFiltered;
+using ProjectPet.VolunteerRequests.Contracts.Dto;
+using ProjectPet.VolunteerRequests.Domain.Models;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Queries;
+public class GetByUserId : VolunteerRequestsTestBase
+{
+    protected GetByUserIdPaginatedFilteredHandler _sut;
+
+    public GetByUserId(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<GetByUserIdPaginatedFilteredHandler>();
+    }
+
+    [Fact]
+    public async Task GetByUser_NoFilter_ReturnsEveryRequest()
+    {
+        // Arrange
+        var userId = _fixture.Create<Guid>();
+        var request1 = await SeedVolunteerRequestAsync(userId);
+        var request2 = await SeedVolunteerRequestAndSetToReview(default, userId);
+
+        var query = new GetByUserIdPaginatedFilteredQuery(userId, new(null)) { Page = 0, RecordAmount = 99 };
+
+        // Act
+        var result = await _sut.HandleAsync(query, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var data = result.Value.Data;
+
+        data.Should().HaveCount(2);
+        data.Should().Contain(x => x.Id == request1.Id && x.Status == VolunteerRequestStatusDto.submitted);
+        data.Should().Contain(x => x.Id == request2.Id && x.Status == VolunteerRequestStatusDto.onReview);
+    }
+
+    [Fact]
+    public async Task GetByUser_Filter_Filtered()
+    {
+        // Arrange
+        var userId = _fixture.Create<Guid>();
+
+        var request1 = await SeedVolunteerRequestAsync(userId);
+        var request2 = await SeedVolunteerRequestAndSetToReview(default, userId);
+
+        var query = new GetByUserIdPaginatedFilteredQuery(userId, new(VolunteerRequestStatusDto.onReview)) { Page = 0, RecordAmount = 99 };
+
+        // Act
+        var result = await _sut.HandleAsync(query, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var data = result.Value.Data;
+
+        data.Should().HaveCount(1);
+        data.Should().Contain(x => x.Id == request2.Id && x.Status == VolunteerRequestStatusDto.onReview);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetUnassigned.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetUnassigned.cs
@@ -1,0 +1,40 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPet.VolunteerRequests.Application.Features.VolunteerRequests.Queries.GetUnassignedPaginated;
+using ProjectPet.VolunteerRequests.IntegrationTests.Factories;
+using ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Base;
+
+namespace ProjectPet.VolunteerRequests.IntegrationTests.VolunteerRequestsTests.Queries;
+public class GetUnassigned : VolunteerRequestsTestBase
+{
+    protected GetUnassignedPaginatedHandler _sut;
+
+    public GetUnassigned(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = _serviceScope.ServiceProvider.GetRequiredService<GetUnassignedPaginatedHandler>();
+    }
+
+    [Fact]
+    public async Task Admin1Userx1_Admin2Userx1_Userx1_GetUnassigned_GetsUnassigned()
+    {
+        // Arrange
+        var admin1Id = _fixture.Create<Guid>();
+        var admin2Id = _fixture.Create<Guid>();
+        var volunteer1Admin1 = await SeedVolunteerRequestAndSetToReview(admin1Id, default);
+        var volunteer2Admin2 = await SeedVolunteerRequestAndSetToReview(admin2Id, default);
+        var volunteer3AdminNONE = await SeedVolunteerRequestAsync();
+
+        var query = new GetUnassignedPaginatedQuery() {Page = 0, RecordAmount = 99 };
+
+        // Act
+        var result = await _sut.HandleAsync(query, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var data = result.Value.Data;
+
+        data.Should().HaveCount(1);
+        data.Should().Contain(x => x.Id == volunteer3AdminNONE.Id);
+    }
+}

--- a/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetUnassigned.cs
+++ b/src/VolunteerRequest/Tests/ProjectPet.VolunteerRequests.IntegrationTests/VolunteerRequestsTests/Queries/GetUnassigned.cs
@@ -25,7 +25,7 @@ public class GetUnassigned : VolunteerRequestsTestBase
         var volunteer2Admin2 = await SeedVolunteerRequestAndSetToReview(admin2Id, default);
         var volunteer3AdminNONE = await SeedVolunteerRequestAsync();
 
-        var query = new GetUnassignedPaginatedQuery() {Page = 0, RecordAmount = 99 };
+        var query = new GetUnassignedPaginatedQuery() { Page = 0, RecordAmount = 99 };
 
         // Act
         var result = await _sut.HandleAsync(query, default);


### PR DESCRIPTION
Фичи:
Блокировка от создания новых заявок через новую фичу - модификатор прав в Account модуле, вызов через контракт

Тесты:
Togglemock'и для opt-in моков интерфейсов, по сути работают как scope создавая сервис подтягивая зависимости из ServiceProvider, и как моки при необходимости

Абстрагированное уточнение нужных dbcontext'ов - при использовании нужно только указать тип контекста(ов) и его(их) схему(ы), создание таблиц с RelationalDatabaseCreator createTable после прогрева EnsureCreated первым контекстом

Сидирование ролей и прав, исключение ролевых таблиц от чистки респавнером
